### PR TITLE
app: fix flaky test on slow machines/with -race

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -304,9 +304,9 @@ func makeFriends(a *require.Assertions, peer1, peer2 testPeer) {
 	}, 15*time.Second, 50*time.Millisecond)
 	err = peer2.api.ReplyFriendRequest(authRequests[0].PeerID, "", false)
 	a.NoError(err)
-	a.Len(peer2.app.AuthStatus.GetIngoingAuthRequests(), 0)
 
 	time.Sleep(500 * time.Millisecond)
+	a.Len(peer2.app.AuthStatus.GetIngoingAuthRequests(), 0)
 	knownPeer, exists := peer2.app.Conf.GetPeer(peer1.PeerID())
 	a.True(exists)
 	a.True(knownPeer.Confirmed)


### PR DESCRIPTION
This change should help to avoid CI failures on macOS with -race such as in https://github.com/anywherelan/awl/runs/4192705276?check_suite_focus=true#step:7:58