### PR TITLE
vpn: add macos support

### DIFF
--- a/config/other.go
+++ b/config/other.go
@@ -165,7 +165,11 @@ func setDefaults(conf *Config, bus awlevent.Bus) {
 		conf.VPNConfig.IPNet = defaultNetworkSubnet
 	}
 	if conf.VPNConfig.InterfaceName == "" {
-		conf.VPNConfig.InterfaceName = defaultInterfaceName
+		if runtime.GOOS == "darwin" {
+			conf.VPNConfig.InterfaceName = "utun"
+		} else {
+			conf.VPNConfig.InterfaceName = defaultInterfaceName
+		}
 	}
 
 	uniqAliases := make(map[string]struct{}, len(conf.KnownPeers))


### PR DESCRIPTION
for #18

What's working:
- vpn
- system tray (even under root)

Still need to do:
- fix awldns
- figure out .dmg packaging
- elevate to root (not by `sudo ./awl-tray`, more user-friendly)
- add e2e test in CI