### PR TITLE
app: add vpn tunneling benchmark with simulated network with different bandwidth/latency

### DIFF
--- a/application.go
+++ b/application.go
@@ -71,6 +71,10 @@ type Application struct {
 	Conf      *config.Config
 	Eventbus  awlevent.Bus
 
+	// For tests only:
+	ExtraLibp2pOpts          []libp2p.Option
+	AllowEmptyBootstrapPeers bool
+
 	ctx        context.Context
 	ctxCancel  context.CancelFunc
 	vpnDevice  *vpn.Device
@@ -265,18 +269,19 @@ func (a *Application) makeP2pHostConfig() p2p.HostConfig {
 	}
 
 	return p2p.HostConfig{
-		PrivKeyBytes:    a.Conf.PrivKey(),
-		ListenAddrs:     a.Conf.GetListenAddresses(),
-		UserAgent:       config.UserAgent,
-		BootstrapPeers:  a.Conf.GetBootstrapPeers(),
-		EnableAutoRelay: true,
-		Libp2pOpts: []libp2p.Option{
+		PrivKeyBytes:             a.Conf.PrivKey(),
+		ListenAddrs:              a.Conf.GetListenAddresses(),
+		UserAgent:                config.UserAgent,
+		BootstrapPeers:           a.Conf.GetBootstrapPeers(),
+		AllowEmptyBootstrapPeers: a.AllowEmptyBootstrapPeers,
+		EnableAutoRelay:          true,
+		Libp2pOpts: append([]libp2p.Option{
 			libp2p.EnableRelay(),
 			libp2p.EnableAutoNATv2(),
 			libp2p.ResourceManager(mgr),
 			libp2p.EnableHolePunching(),
 			libp2p.NATPortMap(),
-		},
+		}, a.ExtraLibp2pOpts...),
 		ConnManager: struct {
 			LowWater    int
 			HighWater   int

--- a/application_simnet_test.go
+++ b/application_simnet_test.go
@@ -1,0 +1,225 @@
+package awl
+
+import (
+	"fmt"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	simlibp2p "github.com/libp2p/go-libp2p/x/simlibp2p"
+	"github.com/marcopolo/simnet"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/olekukonko/tablewriter"
+)
+
+/*
+TestSimulatedTunnelPerformance performs a benchmark of the AWL VPN tunnel under simulated network conditions.
+
+It uses:
+1. simlibp2p (github.com/libp2p/go-libp2p/x/simlibp2p): A simulated network transport for libp2p.
+   This allows us to run libp2p hosts that communicate over a simulated network rather than
+   actual OS sockets. This is faster and more deterministic.
+
+2. simnet (github.com/marcopolo/simnet): A network simulator that simlibp2p uses underneath.
+   Simnet allows defining network topologies with specific link properties like latency and bandwidth_mbps.
+   This enables testing how the VPN protocol behaves under "Fiber", "Satellite", or "DSL" conditions.
+*/
+
+func TestSimulatedTunnelPerformance(t *testing.T) {
+	const Mbps = 1_000_000
+
+	if os.Getenv("CI") != "" {
+		t.Skip("skip in CI because it's a benchmark")
+	}
+
+	scenarios := []struct {
+		name          string
+		latency       time.Duration
+		bandwidthMbps int
+	}{
+		{
+			name:          "Fiber_300Mbps_1ms",
+			latency:       1 * time.Millisecond,
+			bandwidthMbps: 300 * Mbps,
+		},
+		{
+			name:          "LongDistFiber_300Mbps_200ms",
+			latency:       200 * time.Millisecond,
+			bandwidthMbps: 300 * Mbps,
+		},
+		{
+			name:          "Cable_10Mbps_1ms",
+			latency:       1 * time.Millisecond,
+			bandwidthMbps: 10 * Mbps,
+		},
+		{
+			name:          "Cable_10Mbps_10ms",
+			latency:       10 * time.Millisecond,
+			bandwidthMbps: 10 * Mbps,
+		},
+		{
+			name:          "Cable_10Mbps_100ms",
+			latency:       100 * time.Millisecond,
+			bandwidthMbps: 10 * Mbps,
+		},
+		{
+			name:          "Cable_10Mbps_200ms",
+			latency:       200 * time.Millisecond,
+			bandwidthMbps: 10 * Mbps,
+		},
+		{
+			name:          "LongDistCable_10Mbps_300ms",
+			latency:       300 * time.Millisecond,
+			bandwidthMbps: 10 * Mbps,
+		},
+		{
+			name:          "Cable_50Mbps_1ms",
+			latency:       1 * time.Millisecond,
+			bandwidthMbps: 50 * Mbps,
+		},
+		{
+			name:          "Cable_50Mbps_10ms",
+			latency:       10 * time.Millisecond,
+			bandwidthMbps: 50 * Mbps,
+		},
+		{
+			name:          "Cable_50Mbps_100ms",
+			latency:       100 * time.Millisecond,
+			bandwidthMbps: 50 * Mbps,
+		},
+		{
+			name:          "Cable_50Mbps_200ms",
+			latency:       200 * time.Millisecond,
+			bandwidthMbps: 50 * Mbps,
+		},
+		{
+			name:          "LongDistCable_50Mbps_300ms",
+			latency:       300 * time.Millisecond,
+			bandwidthMbps: 50 * Mbps,
+		},
+		{
+			name:          "DSL_20Mbps_25ms",
+			latency:       25 * time.Millisecond,
+			bandwidthMbps: 20 * Mbps,
+		},
+		{
+			name:          "LTE_30Mbps_40ms",
+			latency:       40 * time.Millisecond,
+			bandwidthMbps: 30 * Mbps,
+		},
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Scenario", "Latency", "Bandwidth Limit", "Actual Throughput", "Utilization", "Packet Loss"})
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			ts := NewSimnetTestSuite(t)
+
+			net := &simnet.Simnet{}
+			net.LatencyFunc = simnet.StaticLatency(sc.latency)
+			net.Start()
+			defer net.Close()
+
+			// TODO: try with different packet sizes
+			//  we probably should aim for one packet per UDP datagram
+			const packetSize = 3500 // Typical VPN packet size
+			const testDuration = 10 * time.Second
+
+			// Setup link properties for the simulation
+			// We simulate a symmetric link between the two peers
+			linkSettings := simnet.NodeBiDiLinkSettings{
+				Downlink: simnet.LinkSettings{BitsPerSecond: sc.bandwidthMbps},
+				Uplink:   simnet.LinkSettings{BitsPerSecond: sc.bandwidthMbps},
+			}
+
+			// Create two peers
+			ctx := t.Context()
+			extraLibp2pOpts := []libp2p.Option{
+				simlibp2p.QUICSimnet(net, linkSettings),
+			}
+
+			listenAddrs1 := []multiaddr.Multiaddr{
+				multiaddr.StringCast("/ip4/1.2.3.1/udp/1234/quic-v1"),
+			}
+			peer1 := ts.newTestPeer(true, listenAddrs1, extraLibp2pOpts)
+			listenAddrs2 := []multiaddr.Multiaddr{
+				multiaddr.StringCast("/ip4/1.2.3.2/udp/1234/quic-v1"),
+			}
+			peer2 := ts.newTestPeer(true, listenAddrs2, extraLibp2pOpts)
+			ts.makeFriendsSimnet(peer1, peer2)
+
+			packet := testPacket(packetSize)
+			peer2.tun.ReferenceInboundPacketLen = packetSize
+			peer2.tun.ClearInboundCount()
+
+			// Send packets
+			var packetsSent int64
+			done := make(chan struct{})
+			startTime := time.Now()
+
+			go func() {
+				defer close(done)
+				timer := time.NewTimer(testDuration)
+				defer timer.Stop()
+
+				for i := 0; ; i++ {
+					select {
+					case <-timer.C:
+						return
+					case <-ctx.Done():
+						return
+					default:
+						// ok
+					}
+
+					// Send with "batches" to minimize runtime overhead for select
+					for range 10 {
+						peer1.tun.Outbound <- packet
+						atomic.AddInt64(&packetsSent, 1)
+					}
+
+					// TODO:
+					// Slight throttle to keep drops lower
+					// const sleepEvery = 200
+					// if newCount != 0 && newCount%sleepEvery == 0 {
+					//	time.Sleep(1 * time.Millisecond)
+					// }
+				}
+			}()
+
+			// Wait for sender to finish
+			<-done
+			duration := time.Since(startTime)
+
+			// Allow some time for packets to arrive
+			time.Sleep(sc.latency * 2)
+
+			// Collect metrics
+			received := peer2.tun.InboundCount()
+			sent := atomic.LoadInt64(&packetsSent)
+
+			packetLoss := (float64(1) - float64(received)/float64(sent)) * 100
+
+			totalBits := float64(received) * float64(packetSize) * 8
+			actualMbps := (totalBits / duration.Seconds()) / Mbps
+			expectedMbps := sc.bandwidthMbps / Mbps
+
+			utilization := (actualMbps / float64(expectedMbps)) * 100
+
+			table.Append([]string{
+				sc.name,
+				sc.latency.String(),
+				fmt.Sprintf("%d Mbps", expectedMbps),
+				fmt.Sprintf("%.2f Mbps", actualMbps),
+				fmt.Sprintf("%.2f %%", utilization),
+				fmt.Sprintf("%.2f %%", packetLoss),
+				// TODO: calculate p50/p95/p99 latency, jitter
+			})
+		})
+	}
+
+	table.Render()
+}

--- a/application_test.go
+++ b/application_test.go
@@ -1,17 +1,12 @@
 package awl
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -19,42 +14,20 @@ import (
 	"testing"
 	"time"
 
-	ds "github.com/ipfs/go-datastore"
-	dssync "github.com/ipfs/go-datastore/sync"
-	"github.com/ipfs/go-log/v2"
-	"github.com/libp2p/go-libp2p"
-	dht "github.com/libp2p/go-libp2p-kad-dht"
-	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
-	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
-	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/quic-go/quic-go/integrationtests/tools/israce"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/proxy"
-	"golang.zx2c4.com/wireguard/tun"
 
 	"github.com/anywherelan/awl/api"
-	"github.com/anywherelan/awl/api/apiclient"
 	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/entity"
-	"github.com/anywherelan/awl/p2p"
-	"github.com/anywherelan/awl/vpn"
 )
-
-func init() {
-	// TODO: move to config
-	useAwldns = false
-	config.DefaultBootstrapPeers = nil
-}
 
 func TestMakeFriends(t *testing.T) {
 	ts := NewTestSuite(t)
 
-	peer1 := ts.newTestPeer(false)
-	peer2 := ts.newTestPeer(false)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
 
 	ts.makeFriends(peer2, peer1)
 }
@@ -62,8 +35,8 @@ func TestMakeFriends(t *testing.T) {
 func TestRemovePeer(t *testing.T) {
 	ts := NewTestSuite(t)
 
-	peer1 := ts.newTestPeer(false)
-	peer2 := ts.newTestPeer(false)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
 
 	ts.makeFriends(peer2, peer1)
 
@@ -112,15 +85,13 @@ func TestRemovePeer(t *testing.T) {
 	// test ping
 	p1Ping := peer1.app.P2p.GetPeerLatency(peer2.app.P2p.PeerID())
 	ts.NotEmpty(p1Ping)
-	p2Ping := peer2.app.P2p.GetPeerLatency(peer1.app.P2p.PeerID())
-	ts.NotEmpty(p2Ping)
 }
 
 func TestDeclinePeerFriendRequest(t *testing.T) {
 	ts := NewTestSuite(t)
 
-	peer1 := ts.newTestPeer(false)
-	peer2 := ts.newTestPeer(false)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
 	ts.ensurePeersAvailableInDHT(peer1, peer2)
 
 	err := peer1.api.SendFriendRequest(peer2.PeerID(), "peer_2")
@@ -149,8 +120,8 @@ func TestDeclinePeerFriendRequest(t *testing.T) {
 func TestAutoAcceptFriendRequest(t *testing.T) {
 	ts := NewTestSuite(t)
 
-	peer1 := ts.newTestPeer(false)
-	peer2 := ts.newTestPeer(false)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
 	ts.ensurePeersAvailableInDHT(peer1, peer2)
 
 	peer2.app.Conf.Lock()
@@ -181,9 +152,9 @@ func TestAutoAcceptFriendRequest(t *testing.T) {
 func TestUniquePeerAlias(t *testing.T) {
 	ts := NewTestSuite(t)
 
-	peer1 := ts.newTestPeer(false)
-	peer2 := ts.newTestPeer(false)
-	peer3 := ts.newTestPeer(false)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	peer3 := ts.NewTestPeer(false)
 	ts.ensurePeersAvailableInDHT(peer1, peer2)
 	ts.ensurePeersAvailableInDHT(peer2, peer3)
 
@@ -199,8 +170,8 @@ func TestUniquePeerAlias(t *testing.T) {
 func TestUpdateUseAsExitNodeConfig(t *testing.T) {
 	ts := NewTestSuite(t)
 
-	peer1 := ts.newTestPeer(false)
-	peer2 := ts.newTestPeer(false)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
 
 	ts.makeFriends(peer2, peer1)
 
@@ -281,7 +252,10 @@ func TestUpdateUseAsExitNodeConfig(t *testing.T) {
 		return !peer2Config.AllowedUsingAsExitNode && peer2Config.WeAllowUsingAsExitNode
 	}, 15*time.Second, 100*time.Millisecond)
 
-	ts.Equal("", peer1.app.Conf.SOCKS5.UsingPeerID)
+	peer1.app.Conf.Lock()
+	peer1Socks5UsingPeerID := peer1.app.Conf.SOCKS5.UsingPeerID
+	peer1.app.Conf.Unlock()
+	ts.Equal("", peer1Socks5UsingPeerID)
 
 	availableProxies, err = peer1.api.ListAvailableProxies()
 	ts.NoError(err)
@@ -317,9 +291,9 @@ func TestUpdateUseAsExitNodeConfig(t *testing.T) {
 func TestUpdatePeerSettingsIPAddr(t *testing.T) {
 	ts := NewTestSuite(t)
 
-	peer1 := ts.newTestPeer(false)
-	peer2 := ts.newTestPeer(false)
-	peer3 := ts.newTestPeer(false)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	peer3 := ts.NewTestPeer(false)
 
 	// Make peer2 and peer1 friends using the helper
 	ts.makeFriends(peer2, peer1)
@@ -688,8 +662,8 @@ func TestTunnelPackets(t *testing.T) {
 
 	ts := NewTestSuite(t)
 
-	peer1 := ts.newTestPeer(false)
-	peer2 := ts.newTestPeer(false)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
 
 	ts.makeFriends(peer2, peer1)
 
@@ -704,7 +678,7 @@ func TestTunnelPackets(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 
-	sendPackets := func(peer, peerWithInbound testPeer) {
+	sendPackets := func(peer, peerWithInbound TestPeer) {
 		defer wg.Done()
 		packet := testPacket(packetSize)
 
@@ -736,8 +710,8 @@ func BenchmarkTunnelPackets(b *testing.B) {
 		b.Run(fmt.Sprintf("%d bytes per package", packetSize), func(b *testing.B) {
 			ts := NewTestSuite(b)
 
-			peer1 := ts.newTestPeer(true)
-			peer2 := ts.newTestPeer(true)
+			peer1 := ts.NewTestPeer(true)
+			peer2 := ts.NewTestPeer(true)
 
 			ts.makeFriends(peer2, peer1)
 			b.ResetTimer()
@@ -765,308 +739,4 @@ func BenchmarkTunnelPackets(b *testing.B) {
 			b.ReportMetric(packetLoss, "packet_loss")
 		})
 	}
-}
-
-func testPacket(length int) []byte {
-	return testPacketWithDest(length, "10.66.0.2")
-}
-
-func testPacketWithDest(length int, destIP string) []byte {
-	data, err := hex.DecodeString("4500002828f540004011fd490a4200010a420002a9d0238200148bfd68656c6c6f20776f726c6421")
-	if err != nil {
-		panic(err)
-	}
-
-	packet := data
-	if length > len(data) {
-		packet = make([]byte, length)
-		copy(packet, data)
-		_, err = rand.Read(packet[len(data):])
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	vpnPacket := vpn.Packet{}
-	_, err = vpnPacket.ReadFrom(bytes.NewReader(packet))
-	if err != nil {
-		panic(err)
-	}
-	vpnPacket.Parse()
-
-	destIPParsed := net.ParseIP(destIP).To4()
-	if destIPParsed == nil {
-		panic(fmt.Sprintf("invalid destination IP: %s", destIP))
-	}
-	copy(vpnPacket.Dst, destIPParsed)
-
-	vpnPacket.RecalculateChecksum()
-
-	return vpnPacket.Packet
-}
-
-// TODO: add support for goleak in TestSuite
-type TestSuite struct {
-	*require.Assertions
-
-	t                 testing.TB
-	bootstrapAddrs    []peer.AddrInfo
-	bootstrapAddrsStr []string
-}
-
-func NewTestSuite(t testing.TB) *TestSuite {
-	if os.Getenv("CI") != "" && runtime.GOOS == "linux" {
-		t.Skip("doesn't work on linux in CI, flaky ensurePeersAvailableInDHT can't find peers")
-	}
-
-	ts := &TestSuite{t: t, Assertions: require.New(t)}
-	ts.initBootstrapNode()
-	ts.initBootstrapNode()
-
-	return ts
-}
-
-type testPeer struct {
-	app *Application
-	api *apiclient.Client
-	tun *TestTUN
-}
-
-func (tp testPeer) Close() {
-	tp.app.Close()
-}
-
-func (tp testPeer) PeerID() string {
-	return tp.app.Conf.P2pNode.PeerID
-}
-
-func (ts *TestSuite) newTestPeer(disableLogging bool) testPeer {
-	tempDir := ts.t.TempDir()
-	ts.t.Setenv(config.AppDataDirEnvKey, tempDir)
-	tempConf := config.NewConfig(eventbus.NewBus())
-	if disableLogging {
-		tempConf.LoggerLevel = "fatal"
-		log.SetAllLoggers(log.LevelFatal)
-	}
-	tempConf.Save()
-
-	app := New()
-	app.SetupLoggerAndConfig()
-	if disableLogging {
-		log.SetupLogging(zapcore.NewNopCore(), func(string) zapcore.Level {
-			return zapcore.FatalLevel
-		})
-	}
-	app.Conf.HttpListenAddress = "127.0.0.1:0"
-	app.Conf.HttpListenOnAdminHost = false
-	app.Conf.SetListenAddresses([]multiaddr.Multiaddr{
-		multiaddr.StringCast("/ip4/127.0.0.1/tcp/0"),
-		multiaddr.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"),
-	})
-	app.Conf.P2pNode.BootstrapPeers = ts.bootstrapAddrsStr
-	app.Conf.SOCKS5 = config.SOCKS5Config{
-		ListenerEnabled: true,
-		ProxyingEnabled: true,
-		ListenAddress:   pickFreeAddr(ts.t),
-		UsingPeerID:     "",
-	}
-
-	testTUN := NewTestTUN()
-	err := app.Init(context.Background(), testTUN.TUN())
-	ts.NoError(err)
-
-	tp := testPeer{
-		app: app,
-		api: apiclient.New(app.Api.Address()),
-		tun: testTUN,
-	}
-
-	ts.t.Cleanup(func() {
-		tp.Close()
-	})
-
-	return tp
-}
-
-func (ts *TestSuite) initBootstrapNode() {
-	peerstore, err := pstoremem.NewPeerstore()
-	ts.NoError(err)
-	resourceLimitsConfig := rcmgr.InfiniteLimits
-	mgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(resourceLimitsConfig))
-	ts.NoError(err)
-
-	hostConfig := p2p.HostConfig{
-		PrivKeyBytes: nil,
-		ListenAddrs: []multiaddr.Multiaddr{
-			multiaddr.StringCast("/ip4/127.0.0.1/tcp/0"),
-			multiaddr.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"),
-		},
-		UserAgent:                config.UserAgent,
-		BootstrapPeers:           ts.bootstrapAddrs,
-		AllowEmptyBootstrapPeers: true,
-		Libp2pOpts: []libp2p.Option{
-			libp2p.DisableRelay(),
-			libp2p.ForceReachabilityPublic(),
-			libp2p.ResourceManager(mgr),
-		},
-		Peerstore:    peerstore,
-		DHTDatastore: dssync.MutexWrap(ds.NewMapDatastore()),
-		DHTOpts: []dht.Option{
-			dht.Mode(dht.ModeServer),
-		},
-	}
-
-	p2pSrv := p2p.NewP2p(context.Background())
-	p2pHost, err := p2pSrv.InitHost(hostConfig)
-	ts.NoError(err)
-	err = p2pSrv.Bootstrap()
-	ts.NoError(err)
-
-	peerInfo := peer.AddrInfo{ID: p2pHost.ID(), Addrs: p2pHost.Addrs()}
-	ts.bootstrapAddrs = append(ts.bootstrapAddrs, peerInfo)
-	addrs, err := peer.AddrInfoToP2pAddrs(&peerInfo)
-	ts.NoError(err)
-	for _, addr := range addrs {
-		ts.bootstrapAddrsStr = append(ts.bootstrapAddrsStr, addr.String())
-	}
-
-	ts.t.Cleanup(func() {
-		_ = p2pSrv.Close()
-	})
-}
-
-func (ts *TestSuite) ensurePeersAvailableInDHT(peer1, peer2 testPeer) {
-	ts.Eventually(func() bool {
-		err1 := peer1.app.P2p.Bootstrap()
-		err2 := peer2.app.P2p.Bootstrap()
-		if err1 != nil || err2 != nil {
-			return false
-		}
-
-		_, err1 = peer1.app.P2p.FindPeer(context.Background(), peer2.app.P2p.PeerID())
-		_, err2 = peer2.app.P2p.FindPeer(context.Background(), peer1.app.P2p.PeerID())
-
-		return err1 == nil && err2 == nil
-	}, 20*time.Second, 100*time.Millisecond)
-}
-
-func (ts *TestSuite) makeFriends(peer1, peer2 testPeer) {
-	ts.ensurePeersAvailableInDHT(peer1, peer2)
-	err := peer1.api.SendFriendRequest(peer2.PeerID(), "peer_2")
-	ts.NoError(err)
-
-	var authRequests []entity.AuthRequest
-	ts.Eventually(func() bool {
-		authRequests, err = peer2.api.AuthRequests()
-		ts.NoError(err)
-		return len(authRequests) == 1
-	}, 15*time.Second, 50*time.Millisecond)
-	err = peer2.api.ReplyFriendRequest(authRequests[0].PeerID, "peer_1", false)
-	ts.NoError(err)
-
-	time.Sleep(500 * time.Millisecond)
-	ts.Len(peer2.app.AuthStatus.GetIngoingAuthRequests(), 0)
-	knownPeer, exists := peer2.app.Conf.GetPeer(peer1.PeerID())
-	ts.True(exists)
-	ts.True(knownPeer.Confirmed)
-
-	knownPeer, exists = peer1.app.Conf.GetPeer(peer2.PeerID())
-	ts.True(exists)
-	ts.True(knownPeer.Confirmed)
-}
-
-type TestTUN struct {
-	Outbound                  chan []byte
-	ReferenceInboundPacketLen int
-
-	inboundCount int64
-	closed       chan struct{}
-	events       chan tun.Event
-	tun          testTun
-}
-
-func NewTestTUN() *TestTUN {
-	c := &TestTUN{
-		Outbound: make(chan []byte),
-		closed:   make(chan struct{}),
-		events:   make(chan tun.Event, 1),
-	}
-	c.tun.t = c
-	c.events <- tun.EventUp
-	return c
-}
-
-func (c *TestTUN) TUN() tun.Device {
-	return &c.tun
-}
-
-func (c *TestTUN) InboundCount() int64 {
-	return atomic.LoadInt64(&c.inboundCount)
-}
-
-func (c *TestTUN) ClearInboundCount() {
-	atomic.StoreInt64(&c.inboundCount, 0)
-}
-
-type testTun struct {
-	t *TestTUN
-}
-
-func (t *testTun) File() *os.File { return nil }
-
-func (t *testTun) Read(bufs [][]byte, sizes []int, offset int) (n int, err error) {
-	for i, buf := range bufs {
-		select {
-		case <-t.t.closed:
-			return n, os.ErrClosed
-		case msg := <-t.t.Outbound:
-			copyN := copy(buf[offset:], msg)
-			sizes[i] = copyN
-			n++
-		}
-	}
-
-	return n, nil
-}
-
-func (t *testTun) Write(bufs [][]byte, offset int) (n int, err error) {
-	for _, buf := range bufs {
-		msg := buf[offset:]
-		if len(msg) != t.t.ReferenceInboundPacketLen {
-			return n, errors.New("packets length mismatch")
-		}
-		select {
-		case <-t.t.closed:
-			return n, os.ErrClosed
-		default:
-		}
-		atomic.AddInt64(&t.t.inboundCount, 1)
-		n++
-	}
-
-	return n, nil
-}
-
-func (t *testTun) BatchSize() int {
-	return 1
-}
-
-func (t *testTun) Flush() error             { return nil }
-func (t *testTun) MTU() (int, error)        { return vpn.InterfaceMTU, nil }
-func (t *testTun) Name() (string, error)    { return "testTun", nil }
-func (t *testTun) Events() <-chan tun.Event { return t.t.events }
-func (t *testTun) Close() error {
-	close(t.t.closed)
-	close(t.t.events)
-	return nil
-}
-
-func pickFreeAddr(t testing.TB) string {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer l.Close()
-
-	return l.Addr().String()
 }

--- a/cmd/awl-tray/go.sum
+++ b/cmd/awl-tray/go.sum
@@ -165,8 +165,8 @@ github.com/libp2p/go-reuseport v0.4.0 h1:nR5KU7hD0WxXCJbmw7r2rhRYruNRl2koHw8fQsc
 github.com/libp2p/go-reuseport v0.4.0/go.mod h1:ZtI03j/wO5hZVDFo2jKywN6bYKWLOy8Se6DrI2E1cLU=
 github.com/libp2p/go-yamux/v5 v5.0.1 h1:f0WoX/bEF2E8SbE4c/k1Mo+/9z0O4oC/hWEA+nfYRSg=
 github.com/libp2p/go-yamux/v5 v5.0.1/go.mod h1:en+3cdX51U0ZslwRdRLrvQsdayFt3TSUKvBGErzpWbU=
-github.com/marcopolo/simnet v0.0.1 h1:rSMslhPz6q9IvJeFWDoMGxMIrlsbXau3NkuIXHGJxfg=
-github.com/marcopolo/simnet v0.0.1/go.mod h1:WDaQkgLAjqDUEBAOXz22+1j6wXKfGlC5sD5XWt3ddOs=
+github.com/marcopolo/simnet v0.0.4 h1:50Kx4hS9kFGSRIbrt9xUS3NJX33EyPqHVmpXvaKLqrY=
+github.com/marcopolo/simnet v0.0.4/go.mod h1:tfQF1u2DmaB6WHODMtQaLtClEf3a296CKQLq5gAsIS0=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/libp2p/go-libp2p v0.46.0
 	github.com/libp2p/go-libp2p-kad-dht v0.36.0
 	github.com/libp2p/go-libp2p-kbucket v0.8.0
+	github.com/marcopolo/simnet v0.0.4
 	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/miekg/dns v1.1.69
 	github.com/milosgajdos/tenus v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/libp2p/go-reuseport v0.4.0 h1:nR5KU7hD0WxXCJbmw7r2rhRYruNRl2koHw8fQsc
 github.com/libp2p/go-reuseport v0.4.0/go.mod h1:ZtI03j/wO5hZVDFo2jKywN6bYKWLOy8Se6DrI2E1cLU=
 github.com/libp2p/go-yamux/v5 v5.0.1 h1:f0WoX/bEF2E8SbE4c/k1Mo+/9z0O4oC/hWEA+nfYRSg=
 github.com/libp2p/go-yamux/v5 v5.0.1/go.mod h1:en+3cdX51U0ZslwRdRLrvQsdayFt3TSUKvBGErzpWbU=
-github.com/marcopolo/simnet v0.0.1 h1:rSMslhPz6q9IvJeFWDoMGxMIrlsbXau3NkuIXHGJxfg=
-github.com/marcopolo/simnet v0.0.1/go.mod h1:WDaQkgLAjqDUEBAOXz22+1j6wXKfGlC5sD5XWt3ddOs=
+github.com/marcopolo/simnet v0.0.4 h1:50Kx4hS9kFGSRIbrt9xUS3NJX33EyPqHVmpXvaKLqrY=
+github.com/marcopolo/simnet v0.0.4/go.mod h1:tfQF1u2DmaB6WHODMtQaLtClEf3a296CKQLq5gAsIS0=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/test_suite_test.go
+++ b/test_suite_test.go
@@ -1,0 +1,390 @@
+package awl
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+	"github.com/libp2p/go-libp2p/p2p/host/peerstore/pstoremem"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"golang.zx2c4.com/wireguard/tun"
+
+	"github.com/anywherelan/awl/api/apiclient"
+	"github.com/anywherelan/awl/config"
+	"github.com/anywherelan/awl/entity"
+	"github.com/anywherelan/awl/p2p"
+	"github.com/anywherelan/awl/vpn"
+)
+
+func init() {
+	// TODO: move to config
+	useAwldns = false
+	config.DefaultBootstrapPeers = nil
+}
+
+// TODO: add support for goleak in TestSuite
+type TestSuite struct {
+	*require.Assertions
+
+	t                 testing.TB
+	isSimnet          bool
+	bootstrapAddrs    []peer.AddrInfo
+	bootstrapAddrsStr []string
+}
+
+func NewTestSuite(t testing.TB) *TestSuite {
+	// TODO: fix
+	if os.Getenv("CI") != "" && runtime.GOOS == "linux" {
+		t.Skip("doesn't work on linux in CI, flaky ensurePeersAvailableInDHT can't find peers")
+	}
+
+	ts := &TestSuite{t: t, Assertions: require.New(t)}
+	ts.initBootstrapNode()
+	ts.initBootstrapNode()
+
+	return ts
+}
+
+func NewSimnetTestSuite(t testing.TB) *TestSuite {
+	ts := &TestSuite{t: t, Assertions: require.New(t), isSimnet: true}
+
+	return ts
+}
+
+type TestPeer struct {
+	app *Application
+	api *apiclient.Client
+	tun *TestTUN
+}
+
+func (tp TestPeer) Close() {
+	tp.app.Close()
+}
+
+func (tp TestPeer) PeerID() string {
+	return tp.app.Conf.P2pNode.PeerID
+}
+
+func (ts *TestSuite) NewTestPeer(disableLogging bool) TestPeer {
+	listenAddrs := []multiaddr.Multiaddr{
+		multiaddr.StringCast("/ip4/127.0.0.1/tcp/0"),
+		multiaddr.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"),
+	}
+	return ts.newTestPeer(disableLogging, listenAddrs, nil)
+}
+
+func (ts *TestSuite) newTestPeer(disableLogging bool, listenAddrs []multiaddr.Multiaddr, extraLibp2pOpts []libp2p.Option) TestPeer {
+	tempDir := ts.t.TempDir()
+	ts.t.Setenv(config.AppDataDirEnvKey, tempDir)
+	tempConf := config.NewConfig(eventbus.NewBus())
+	if disableLogging {
+		tempConf.LoggerLevel = "fatal"
+		log.SetAllLoggers(log.LevelFatal)
+	}
+	tempConf.Save()
+
+	app := New()
+	app.AllowEmptyBootstrapPeers = ts.isSimnet
+	app.ExtraLibp2pOpts = extraLibp2pOpts
+
+	app.SetupLoggerAndConfig()
+	if disableLogging {
+		log.SetupLogging(zapcore.NewNopCore(), func(string) zapcore.Level {
+			return zapcore.FatalLevel
+		})
+	}
+	app.Conf.HttpListenAddress = "127.0.0.1:0"
+	app.Conf.HttpListenOnAdminHost = false
+	app.Conf.SetListenAddresses(listenAddrs)
+	app.Conf.P2pNode.BootstrapPeers = ts.bootstrapAddrsStr
+	if ts.isSimnet {
+		app.Conf.SOCKS5 = config.SOCKS5Config{
+			ListenerEnabled: false,
+			ProxyingEnabled: false,
+		}
+	} else {
+		app.Conf.SOCKS5 = config.SOCKS5Config{
+			ListenerEnabled: true,
+			ProxyingEnabled: true,
+			ListenAddress:   pickFreeAddr(ts.t),
+			UsingPeerID:     "",
+		}
+	}
+
+	testTUN := NewTestTUN()
+	err := app.Init(context.Background(), testTUN.TUN())
+	ts.NoError(err)
+
+	tp := TestPeer{
+		app: app,
+		api: apiclient.New(app.Api.Address()),
+		tun: testTUN,
+	}
+
+	ts.t.Cleanup(func() {
+		tp.Close()
+	})
+
+	return tp
+}
+
+// TODO: rewrite bootstrap node using newTestPeer
+func (ts *TestSuite) initBootstrapNode() {
+	peerstore, err := pstoremem.NewPeerstore()
+	ts.NoError(err)
+	resourceLimitsConfig := rcmgr.InfiniteLimits
+	mgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(resourceLimitsConfig))
+	ts.NoError(err)
+
+	hostConfig := p2p.HostConfig{
+		PrivKeyBytes: nil,
+		ListenAddrs: []multiaddr.Multiaddr{
+			multiaddr.StringCast("/ip4/127.0.0.1/tcp/0"),
+			multiaddr.StringCast("/ip4/127.0.0.1/udp/0/quic-v1"),
+		},
+		UserAgent:                config.UserAgent,
+		BootstrapPeers:           ts.bootstrapAddrs,
+		AllowEmptyBootstrapPeers: true,
+		Libp2pOpts: []libp2p.Option{
+			libp2p.DisableRelay(),
+			libp2p.ForceReachabilityPublic(),
+			libp2p.ResourceManager(mgr),
+		},
+		Peerstore:    peerstore,
+		DHTDatastore: dssync.MutexWrap(ds.NewMapDatastore()),
+		DHTOpts: []dht.Option{
+			dht.Mode(dht.ModeServer),
+		},
+	}
+
+	p2pSrv := p2p.NewP2p(context.Background())
+	p2pHost, err := p2pSrv.InitHost(hostConfig)
+	ts.NoError(err)
+	err = p2pSrv.Bootstrap()
+	ts.NoError(err)
+
+	peerInfo := peer.AddrInfo{ID: p2pHost.ID(), Addrs: p2pHost.Addrs()}
+	ts.bootstrapAddrs = append(ts.bootstrapAddrs, peerInfo)
+	addrs, err := peer.AddrInfoToP2pAddrs(&peerInfo)
+	ts.NoError(err)
+	for _, addr := range addrs {
+		ts.bootstrapAddrsStr = append(ts.bootstrapAddrsStr, addr.String())
+	}
+
+	ts.t.Cleanup(func() {
+		_ = p2pSrv.Close()
+	})
+}
+
+func (ts *TestSuite) ensurePeersAvailableInDHT(peer1, peer2 TestPeer) {
+	ts.Eventually(func() bool {
+		err1 := peer1.app.P2p.Bootstrap()
+		err2 := peer2.app.P2p.Bootstrap()
+		if err1 != nil || err2 != nil {
+			return false
+		}
+
+		_, err1 = peer1.app.P2p.FindPeer(context.Background(), peer2.app.P2p.PeerID())
+		_, err2 = peer2.app.P2p.FindPeer(context.Background(), peer1.app.P2p.PeerID())
+
+		return err1 == nil && err2 == nil
+	}, 20*time.Second, 100*time.Millisecond)
+}
+
+func (ts *TestSuite) makeFriends(peer1, peer2 TestPeer) {
+	ts.ensurePeersAvailableInDHT(peer1, peer2)
+	ts.sendAndAcceptFriendRequest(peer1, peer2)
+}
+
+func (ts *TestSuite) makeFriendsSimnet(peer1, peer2 TestPeer) {
+	// Direct connection in simlibp2p/simnet
+	// Can't use DHT here because we don't have bootstrap peers
+
+	p2Info := peer.AddrInfo{
+		ID:    peer2.app.P2p.PeerID(),
+		Addrs: peer2.app.P2p.Host().Addrs(),
+	}
+	ctx, cancel := context.WithTimeout(peer1.app.Ctx(), 5*time.Second)
+	defer cancel()
+	err := peer1.app.P2p.Host().Connect(ctx, p2Info)
+	ts.NoError(err)
+
+	ts.sendAndAcceptFriendRequest(peer1, peer2)
+}
+
+func (ts *TestSuite) sendAndAcceptFriendRequest(peer1, peer2 TestPeer) {
+	err := peer1.api.SendFriendRequest(peer2.PeerID(), "peer_2")
+	ts.NoError(err)
+
+	var authRequests []entity.AuthRequest
+	ts.Eventually(func() bool {
+		authRequests, err = peer2.api.AuthRequests()
+		ts.NoError(err)
+		return len(authRequests) == 1
+	}, 15*time.Second, 50*time.Millisecond)
+	err = peer2.api.ReplyFriendRequest(authRequests[0].PeerID, "peer_1", false)
+	ts.NoError(err)
+
+	time.Sleep(500 * time.Millisecond)
+	ts.Len(peer2.app.AuthStatus.GetIngoingAuthRequests(), 0)
+	knownPeer, exists := peer2.app.Conf.GetPeer(peer1.PeerID())
+	ts.True(exists)
+	ts.True(knownPeer.Confirmed)
+
+	knownPeer, exists = peer1.app.Conf.GetPeer(peer2.PeerID())
+	ts.True(exists)
+	ts.True(knownPeer.Confirmed)
+}
+
+type TestTUN struct {
+	Outbound                  chan []byte
+	ReferenceInboundPacketLen int
+
+	inboundCount int64
+	closed       chan struct{}
+	events       chan tun.Event
+	tun          testTun
+}
+
+func NewTestTUN() *TestTUN {
+	c := &TestTUN{
+		Outbound: make(chan []byte),
+		closed:   make(chan struct{}),
+		events:   make(chan tun.Event, 1),
+	}
+	c.tun.t = c
+	c.events <- tun.EventUp
+	return c
+}
+
+func (c *TestTUN) TUN() tun.Device {
+	return &c.tun
+}
+
+func (c *TestTUN) InboundCount() int64 {
+	return atomic.LoadInt64(&c.inboundCount)
+}
+
+func (c *TestTUN) ClearInboundCount() {
+	atomic.StoreInt64(&c.inboundCount, 0)
+}
+
+type testTun struct {
+	t *TestTUN
+}
+
+func (t *testTun) File() *os.File { return nil }
+
+func (t *testTun) Read(bufs [][]byte, sizes []int, offset int) (n int, err error) {
+	for i, buf := range bufs {
+		select {
+		case <-t.t.closed:
+			return n, os.ErrClosed
+		case msg := <-t.t.Outbound:
+			copyN := copy(buf[offset:], msg)
+			sizes[i] = copyN
+			n++
+		}
+	}
+
+	return n, nil
+}
+
+func (t *testTun) Write(bufs [][]byte, offset int) (n int, err error) {
+	for _, buf := range bufs {
+		msg := buf[offset:]
+		if len(msg) != t.t.ReferenceInboundPacketLen {
+			return n, errors.New("packets length mismatch")
+		}
+		select {
+		case <-t.t.closed:
+			return n, os.ErrClosed
+		default:
+		}
+		atomic.AddInt64(&t.t.inboundCount, 1)
+		n++
+	}
+
+	return n, nil
+}
+
+func (t *testTun) BatchSize() int {
+	return 1
+}
+
+func (t *testTun) Flush() error             { return nil }
+func (t *testTun) MTU() (int, error)        { return vpn.InterfaceMTU, nil }
+func (t *testTun) Name() (string, error)    { return "testTun", nil }
+func (t *testTun) Events() <-chan tun.Event { return t.t.events }
+func (t *testTun) Close() error {
+	close(t.t.closed)
+	close(t.t.events)
+	return nil
+}
+
+func pickFreeAddr(t testing.TB) string {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	return l.Addr().String()
+}
+
+func testPacket(length int) []byte {
+	return testPacketWithDest(length, "10.66.0.2")
+}
+
+func testPacketWithDest(length int, destIP string) []byte {
+	data, err := hex.DecodeString("4500002828f540004011fd490a4200010a420002a9d0238200148bfd68656c6c6f20776f726c6421")
+	if err != nil {
+		panic(err)
+	}
+
+	packet := data
+	if length > len(data) {
+		packet = make([]byte, length)
+		copy(packet, data)
+		_, err = rand.Read(packet[len(data):])
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	vpnPacket := vpn.Packet{}
+	_, err = vpnPacket.ReadFrom(bytes.NewReader(packet))
+	if err != nil {
+		panic(err)
+	}
+	vpnPacket.Parse()
+
+	destIPParsed := net.ParseIP(destIP).To4()
+	if destIPParsed == nil {
+		panic(fmt.Sprintf("invalid destination IP: %s", destIP))
+	}
+	copy(vpnPacket.Dst, destIPParsed)
+
+	vpnPacket.RecalculateChecksum()
+
+	return vpnPacket.Packet
+}


### PR DESCRIPTION

Results:

```
+-----------------------------+---------+-----------------+-------------------+-------------+-------------+
|          SCENARIO           | LATENCY | BANDWIDTH LIMIT | ACTUAL THROUGHPUT | UTILIZATION | PACKET LOSS |
+-----------------------------+---------+-----------------+-------------------+-------------+-------------+
| Fiber_300Mbps_1ms           | 1ms     | 300 Mbps        | 227.02 Mbps       | 75.67 %     | 98.04 %     |
| LongDistFiber_300Mbps_200ms | 200ms   | 300 Mbps        | 30.82 Mbps        | 10.27 %     | 99.78 %     |
| Cable_10Mbps_1ms            | 1ms     | 10 Mbps         | 9.72 Mbps         | 97.22 %     | 99.93 %     |
| Cable_10Mbps_10ms           | 10ms    | 10 Mbps         | 9.74 Mbps         | 97.38 %     | 99.94 %     |
| Cable_10Mbps_100ms          | 100ms   | 10 Mbps         | 7.97 Mbps         | 79.66 %     | 99.95 %     |
| Cable_10Mbps_200ms          | 200ms   | 10 Mbps         | 6.95 Mbps         | 69.52 %     | 99.96 %     |
| LongDistCable_10Mbps_300ms  | 300ms   | 10 Mbps         | 6.38 Mbps         | 63.76 %     | 99.96 %     |
| Cable_50Mbps_1ms            | 1ms     | 50 Mbps         | 48.56 Mbps        | 97.12 %     | 99.68 %     |
| Cable_50Mbps_10ms           | 10ms    | 50 Mbps         | 48.05 Mbps        | 96.10 %     | 99.71 %     |
| Cable_50Mbps_100ms          | 100ms   | 50 Mbps         | 34.14 Mbps        | 68.28 %     | 99.75 %     |
| Cable_50Mbps_200ms          | 200ms   | 50 Mbps         | 19.95 Mbps        | 39.91 %     | 99.86 %     |
| LongDistCable_50Mbps_300ms  | 300ms   | 50 Mbps         | 14.23 Mbps        | 28.45 %     | 99.90 %     |
| DSL_20Mbps_25ms             | 25ms    | 20 Mbps         | 18.12 Mbps        | 90.61 %     | 99.88 %     |
| LTE_30Mbps_40ms             | 40ms    | 30 Mbps         | 26.77 Mbps        | 89.23 %     | 99.82 %     |
+-----------------------------+---------+-----------------+-------------------+-------------+-------------+
```

As observed in real testing, throughput degrades significantly with high latency. Fixes will be coming in future PRs.