### PR TITLE
config: update defaults

### DIFF
--- a/application.go
+++ b/application.go
@@ -201,12 +201,12 @@ func (a *Application) Init(ctx context.Context, tunDevice tun.Device) error {
 	return nil
 }
 
-func (a *Application) SetupLoggerAndConfig() *log.ZapEventLogger {
+func (a *Application) SetupLoggerAndConfig(appType config.AppType) *log.ZapEventLogger {
 	a.Eventbus = eventbus.NewBus()
 	// Config
-	conf, loadConfigErr := config.LoadConfig(a.Eventbus)
+	conf, loadConfigErr := config.LoadConfig(appType, a.Eventbus)
 	if loadConfigErr != nil {
-		conf = config.NewConfig(a.Eventbus)
+		conf = config.NewConfig(appType, a.Eventbus)
 	}
 
 	// Logger

--- a/application_test.go
+++ b/application_test.go
@@ -568,7 +568,7 @@ func TestUpdatePeerSettingsIPAddr(t *testing.T) {
 			{"different network", "192.168.1.1"},
 			{"next network up", "10.67.0.5"},
 			{"next network down", "10.65.255.255"},
-			{"same class B different C", "10.66.1.1"},
+			{"same class B different C", "10.67.1.1"},
 		}
 
 		for _, tc := range testCases {
@@ -581,7 +581,7 @@ func TestUpdatePeerSettingsIPAddr(t *testing.T) {
 					AllowUsingAsExitNode: peer2Config.WeAllowUsingAsExitNode,
 				})
 				ts.Error(err)
-				ts.ErrorContains(err, "IP "+tc.ip+" does not belong to subnet 10.66.0.0/24")
+				ts.ErrorContains(err, "IP "+tc.ip+" does not belong to subnet 10.66.0.0/16")
 			})
 		}
 	})

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -32,16 +32,16 @@ var defaultApiAddr = "127.0.0.1:" + strconv.Itoa(config.DefaultHTTPPort)
 var binaryName = path.Base(os.Args[0])
 
 type Application struct {
-	logger     *log.ZapEventLogger
-	api        *apiclient.Client
-	cliapp     *cli.App
-	updateType update.ApplicationType
+	logger  *log.ZapEventLogger
+	api     *apiclient.Client
+	cliapp  *cli.App
+	appType config.AppType
 }
 
-func New(updateType update.ApplicationType) *Application {
+func New(appType config.AppType) *Application {
 	app := new(Application)
 	app.logger = log.Logger("awl/cli")
-	app.updateType = updateType
+	app.appType = appType
 	app.init()
 
 	return app
@@ -518,12 +518,12 @@ func (a *Application) init() {
 				Action: func(c *cli.Context) error {
 					_, _ = fmt.Fprintf(a.cliapp.Writer, "current version: %s\n", config.Version)
 
-					conf, err := config.LoadConfig(eventbus.NewBus())
+					conf, err := config.LoadConfig(a.appType, eventbus.NewBus())
 					if err != nil {
 						return fmt.Errorf("update: read config: %v", err)
 					}
 
-					updService, err := update.NewUpdateService(conf, a.logger, a.updateType)
+					updService, err := update.NewUpdateService(conf, a.logger, a.appType)
 					if err != nil {
 						return fmt.Errorf("update: create update service: %v", err)
 					}
@@ -570,7 +570,7 @@ func (a *Application) initApiConnection(c *cli.Context) error {
 		return a.initApiFromAddr(apiAddr, username, password)
 	}
 
-	conf, errConfig := config.LoadConfig(eventbus.NewBus())
+	conf, errConfig := config.LoadConfig(a.appType, eventbus.NewBus())
 	if errConfig == nil {
 		if username == "" && password == "" {
 			username = conf.HttpBasicAuth.Username

--- a/cli_test.go
+++ b/cli_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/anywherelan/awl/cli"
+	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/entity"
-	"github.com/anywherelan/awl/update"
 )
 
 // runCLIAddr runs a CLI command against the given API address and returns stdout output.
 func runCLIAddr(addr string, args ...string) (string, error) {
-	app := cli.New(update.AppTypeAwl)
+	app := cli.New(config.AppTypeAwl)
 	var buf bytes.Buffer
 	fullArgs := append([]string{"cli", "--api_addr", addr}, args...)
 	err := app.RunWithWriter(fullArgs, &buf)

--- a/cmd/awl-tray/main.go
+++ b/cmd/awl-tray/main.go
@@ -23,8 +23,9 @@ import (
 	"github.com/anywherelan/awl/cli"
 	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/embeds"
-	"github.com/anywherelan/awl/update"
 )
+
+const appType = config.AppTypeAwlTray
 
 var (
 	app    *awl.Application
@@ -35,11 +36,11 @@ func getConfig() (*config.Config, error) {
 	if app != nil {
 		return app.Conf, nil
 	}
-	return config.LoadConfig(eventbus.NewBus())
+	return config.LoadConfig(appType, eventbus.NewBus())
 }
 
 func main() {
-	cli.New(update.AppTypeAwlTray).Run()
+	cli.New(appType).Run()
 
 	initOSSpecificHacks()
 
@@ -105,7 +106,7 @@ func InitServer() (err error) {
 	app = awl.New()
 	// TODO: setup logger in main(), before systray and others
 	//  now we can have panics because of this
-	logger = app.SetupLoggerAndConfig()
+	logger = app.SetupLoggerAndConfig(appType)
 
 	err = app.Init(context.Background(), nil)
 	if err != nil {

--- a/cmd/awl-tray/tray.go
+++ b/cmd/awl-tray/tray.go
@@ -402,7 +402,7 @@ func onClickUpdateMenu() error {
 	if err != nil {
 		return fmt.Errorf("update: read config: %v", err)
 	}
-	updService, err := update.NewUpdateService(conf, logger, update.AppTypeAwlTray)
+	updService, err := update.NewUpdateService(conf, logger, appType)
 	if err != nil {
 		return fmt.Errorf("update: create update service: %v", err)
 	}
@@ -438,7 +438,7 @@ func checkForUpdatesWithDesktopNotification() {
 		logger.Errorf("update auto check: load config: %v", err)
 		return
 	}
-	updService, err := update.NewUpdateService(conf, logger, update.AppTypeAwlTray)
+	updService, err := update.NewUpdateService(conf, logger, appType)
 	if err != nil {
 		logger.Errorf("update auto check: creating update service: %v", err)
 		return

--- a/cmd/awl/main.go
+++ b/cmd/awl/main.go
@@ -9,15 +9,18 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ipfs/go-log/v2"
+
 	"github.com/anywherelan/awl"
 	"github.com/anywherelan/awl/cli"
 	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/update"
-	"github.com/ipfs/go-log/v2"
 )
 
+const appType = config.AppTypeAwl
+
 func main() {
-	cli.New(update.AppTypeAwl).Run()
+	cli.New(appType).Run()
 
 	uid := os.Geteuid()
 	if uid == 0 {
@@ -30,7 +33,7 @@ func main() {
 	}
 
 	app := awl.New()
-	logger := app.SetupLoggerAndConfig()
+	logger := app.SetupLoggerAndConfig(appType)
 	ctx, ctxCancel := context.WithCancel(context.Background())
 
 	err := app.Init(ctx, nil)
@@ -82,7 +85,7 @@ func main() {
 }
 
 func checkForUpdates(conf *config.Config, logger *log.ZapEventLogger) {
-	updService, err := update.NewUpdateService(conf, logger, update.AppTypeAwl)
+	updService, err := update.NewUpdateService(conf, logger, appType)
 	if err != nil {
 		logger.Errorf("update auto check: creating update service: %v", err)
 		return

--- a/cmd/gomobile-lib/main.go
+++ b/cmd/gomobile-lib/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/anywherelan/awl/vpn/sockmark"
 )
 
+const appType = config.AppTypeAwlAndroid
+
 var (
 	globalApp     *awl.Application
 	globalDataDir string
@@ -37,9 +39,9 @@ func GetConfig() string {
 		panic("call to GetConfig before Setup")
 	}
 
-	conf, loadConfigErr := config.LoadConfig(eventbus.NewBus())
+	conf, loadConfigErr := config.LoadConfig(appType, eventbus.NewBus())
 	if loadConfigErr != nil {
-		conf = config.NewConfig(eventbus.NewBus())
+		conf = config.NewConfig(appType, eventbus.NewBus())
 	}
 
 	data := conf.Export()
@@ -77,7 +79,7 @@ func StartServer(tunFD int32, protector SocketProtector) (err error) {
 	}()
 
 	globalApp = awl.New()
-	globalApp.SetupLoggerAndConfig()
+	globalApp.SetupLoggerAndConfig(appType)
 	globalApp.SockMarker = sockmark.NewAndroid(protectorToFunc(protector))
 
 	// A tunFD of 0 means the host did not establish a VPN interface (VPN

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type (
 		sync.RWMutex `swaggerignore:"true"`
 		dataDir      string
 		emitter      awlevent.Emitter
+		appType      AppType
 
 		Version               string                 `json:"version"`
 		LoggerLevel           string                 `json:"loggerLevel"`

--- a/config/network_addr.go
+++ b/config/network_addr.go
@@ -10,7 +10,7 @@ import (
 const (
 	DefaultVPNInterfaceName = "awl0"
 	// TODO: generate subnets if this has already taken
-	DefaultVPNNetworkSubnet = "10.66.0.1/24"
+	DefaultVPNNetworkSubnet = "10.66.0.1/16"
 )
 
 func (c *Config) VPNLocalIPMask() (net.IP, net.IPMask) {

--- a/config/network_addr_test.go
+++ b/config/network_addr_test.go
@@ -106,7 +106,7 @@ func TestGenerateNextIpAddrExcept(t *testing.T) {
 func TestCheckIPUnique(t *testing.T) {
 	conf := &Config{
 		VPNConfig: VPNConfig{
-			IPNet: "10.66.0.0/24",
+			IPNet: "10.66.0.0/16",
 		},
 		KnownPeers: map[string]KnownPeer{
 			"p1": {PeerID: "p1", IPAddr: "10.66.0.1", Alias: "peer1"},
@@ -124,7 +124,7 @@ func TestCheckIPUnique(t *testing.T) {
 		{"ExistingIP", "10.66.0.1", "", "ip 10.66.0.1 is already used by peer peer1"},
 		{"SamePeerIP", "10.66.0.1", "p1", ""},
 		{"InvalidIPFormat", "invalid", "", "invalid IP invalid"},
-		{"OutsideSubnet", "192.168.1.1", "", "IP 192.168.1.1 does not belong to subnet 10.66.0.0/24"},
+		{"OutsideSubnet", "192.168.1.1", "", "IP 192.168.1.1 does not belong to subnet 10.66.0.0/16"},
 	}
 
 	for _, tt := range tests {

--- a/config/other.go
+++ b/config/other.go
@@ -43,8 +43,8 @@ func init() {
 		"/ip6/2607:5300:201:3100::6b5f/tcp/7250/p2p/12D3KooWQeAvoyVnRm6T5XzWpKD8AzM1buzBL6o95iCodCZVQAsV",
 		"/ip6/2607:5300:201:3100::6b5f/udp/7250/quic-v1/p2p/12D3KooWQeAvoyVnRm6T5XzWpKD8AzM1buzBL6o95iCodCZVQAsV",
 		// copy of rus-2 in case dns does not work
-		"/ip4/45.67.230.223/tcp/6150/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
-		"/ip4/45.67.230.223/udp/6150/quic-v1/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
+		"/ip4/193.124.131.112/tcp/6150/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
+		"/ip4/193.124.131.112/udp/6150/quic-v1/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
 
 		// community relay server from pftmclub - location at Vietnam - Hosting Provided by VPSMMO.vn
 		"/ip4/103.77.242.85/tcp/6150/p2p/12D3KooWFdFV4ZcwMhNQuQnzNCp1K1aaQAsAnr8sXJnj7vehtCFW",
@@ -99,13 +99,13 @@ func CalcAppDataDir() string {
 	return userDataDir
 }
 
-func NewConfig(bus awlevent.Bus) *Config {
-	conf := &Config{}
+func NewConfig(appType AppType, bus awlevent.Bus) *Config {
+	conf := &Config{appType: appType}
 	setDefaults(conf, bus)
 	return conf
 }
 
-func LoadConfig(bus awlevent.Bus) (*Config, error) {
+func LoadConfig(appType AppType, bus awlevent.Bus) (*Config, error) {
 	dataDir := CalcAppDataDir()
 	configPath := filepath.Join(dataDir, AppConfigFilename)
 	data, err := os.ReadFile(configPath)
@@ -113,7 +113,7 @@ func LoadConfig(bus awlevent.Bus) (*Config, error) {
 		return nil, err
 	}
 	// TODO: config migration
-	conf := new(Config)
+	conf := &Config{appType: appType}
 	err = json.Unmarshal(data, conf)
 	if err != nil {
 		return nil, err
@@ -167,7 +167,7 @@ func setDefaults(conf *Config, bus awlevent.Bus) {
 	if conf.HttpListenAddress == "" {
 		conf.HttpListenAddress = "127.0.0.1:" + strconv.Itoa(DefaultHTTPPort)
 	}
-	if isEmptyConfig {
+	if isEmptyConfig && conf.appType == AppTypeAwlTray {
 		conf.HttpListenOnAdminHost = true
 	}
 
@@ -188,6 +188,8 @@ func setDefaults(conf *Config, bus awlevent.Bus) {
 	if conf.SOCKS5 == (SOCKS5Config{}) {
 		conf.SOCKS5.ListenerEnabled = true
 		conf.SOCKS5.ProxyingEnabled = true
+		// TODO: generate proxy username/password
+		//  we also need to display it in API and in UI, and pass from Android
 	}
 	if conf.SOCKS5.ListenAddress == "" {
 		conf.SOCKS5.ListenAddress = defaultSOCKS5ListenAddress

--- a/config/version.go
+++ b/config/version.go
@@ -17,6 +17,14 @@ var (
 	IsWindows7 = ""
 )
 
+type AppType int
+
+const (
+	AppTypeAwl AppType = iota
+	AppTypeAwlTray
+	AppTypeAwlAndroid
+)
+
 // IsDevVersion
 // Possible duplicate of *Config.DevMode()
 // Based on build version (unchangeable after build, could be used only by developers)

--- a/test_suite_test.go
+++ b/test_suite_test.go
@@ -192,7 +192,7 @@ func (ts *TestSuite) NewTestPeerExpectingInitError(configModifier ConfigModifier
 func (ts *TestSuite) buildTestPeer(disableLogging bool, listenAddrs []multiaddr.Multiaddr, extraLibp2pOpts []libp2p.Option, configModifier ConfigModifier, appModifier AppModifier) (TestPeer, error) {
 	tempDir := ts.t.TempDir()
 	ts.t.Setenv(config.AppDataDirEnvKey, tempDir)
-	tempConf := config.NewConfig(eventbus.NewBus())
+	tempConf := config.NewConfig(config.AppTypeAwl, eventbus.NewBus())
 	if disableLogging {
 		tempConf.LoggerLevel = "fatal"
 		log.SetAllLoggers(log.LevelFatal)
@@ -207,7 +207,7 @@ func (ts *TestSuite) buildTestPeer(disableLogging bool, listenAddrs []multiaddr.
 	app.SockMarker = noopSockMarker{}
 	app.ExtraLibp2pOpts = extraLibp2pOpts
 
-	app.SetupLoggerAndConfig()
+	app.SetupLoggerAndConfig(config.AppTypeAwl)
 	if disableLogging {
 		log.SetupLogging(zapcore.NewNopCore(), func(string) zapcore.Level {
 			return zapcore.FatalLevel

--- a/update/update.go
+++ b/update/update.go
@@ -32,13 +32,6 @@ type UpdateService struct {
 	logger     *log.ZapEventLogger
 }
 
-type ApplicationType int
-
-const (
-	AppTypeAwl ApplicationType = iota
-	AppTypeAwlTray
-)
-
 var (
 	goos = func() string {
 		if config.IsWindows7 == "true" {
@@ -50,7 +43,7 @@ var (
 	awlTrayFilenamesRegex = regexp.MustCompile(fmt.Sprintf("awl-tray-%s-%s.*", goos, runtime.GOARCH))
 )
 
-func NewUpdateService(c *config.Config, logger *log.ZapEventLogger, appType ApplicationType) (UpdateService, error) {
+func NewUpdateService(c *config.Config, logger *log.ZapEventLogger, appType config.AppType) (UpdateService, error) {
 	if config.IsDevVersion() {
 		return UpdateService{}, errors.New("updates are unsupported for dev version")
 	}
@@ -74,9 +67,9 @@ func NewUpdateService(c *config.Config, logger *log.ZapEventLogger, appType Appl
 
 	filenamesRegex := make([]*regexp.Regexp, 0, 1)
 	switch appType {
-	case AppTypeAwl:
+	case config.AppTypeAwl:
 		filenamesRegex = append(filenamesRegex, awlFilenamesRegex)
-	case AppTypeAwlTray:
+	case config.AppTypeAwlTray:
 		filenamesRegex = append(filenamesRegex, awlTrayFilenamesRegex)
 	default:
 		return UpdateService{}, fmt.Errorf("unknown application type: %v", appType)

--- a/vpn/packet_test.go
+++ b/vpn/packet_test.go
@@ -67,8 +67,8 @@ func TestGetIPv4BroadcastAddress(t *testing.T) {
 	}{
 		{
 			name:  "awl-default",
-			ipNet: getIPNet("10.66.0.1/24"),
-			want:  net.IPv4(10, 66, 0, 255).To4(),
+			ipNet: getIPNet("10.66.0.1/16"),
+			want:  net.IPv4(10, 66, 255, 255).To4(),
 		},
 		{
 			name:  "local-network",

--- a/vpn/routes/vpn_hostnet_integration_test.go
+++ b/vpn/routes/vpn_hostnet_integration_test.go
@@ -49,7 +49,7 @@ import (
 
 const (
 	testTunIf     = "awl0"
-	testAwlSubnet = "10.66.0.0/24"
+	testAwlSubnet = "10.66.0.0/16"
 	ipForwardPath = "/proc/sys/net/ipv4/ip_forward"
 )
 


### PR DESCRIPTION
- update rus-2 bootstrap peer IP
- change subnet from 10.66.0.1/24 to 10.66.0.1/16
- enable HttpListenOnAdminHost by default only for awl-tray. For Android it always fails, and for server version `awl` it's just useless