### PR TITLE
vpn gateway: track routes changes on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,6 @@ On macOS and Windows awl currently refuses to start with VPN gateway enabled.
 > - **Dual-stack (IPv4 + IPv6):** everything automatically uses IPv4 through the tunnel.
 > - **IPv6-only network:** you'll have no internet connectivity until you turn the gateway off.
 
-> **Linux: host network changes mid-session aren't tracked.** If the host switches network (new Wi-Fi, Ethernet or cellular connection) while the gateway is on, restart awl. This will be fixed in a future release.
-
 ### Serve as an exit node
 
 This lets your other devices route their internet traffic out through this one. It is **off by default** — see [Why serving as an exit node is opt-in](#why-serving-as-an-exit-node-is-opt-in) below. Two things need to be set: turn the gateway service on, then allow each specific device to use it. Serving as an exit node is Linux-only (see the status table above).

--- a/api/peers.go
+++ b/api/peers.go
@@ -280,6 +280,7 @@ func (h *Handler) GetAuthRequests(c echo.Context) (err error) {
 // @Success	200		"OK"
 // @Failure	400		{object}	api.Error
 // @Failure	404		{object}	api.Error
+// @Failure	409		{object}	api.Error
 // @Router		/peers/remove [POST]
 func (h *Handler) RemovePeer(c echo.Context) (err error) {
 	req := entity.PeerIDRequest{}
@@ -294,6 +295,18 @@ func (h *Handler) RemovePeer(c echo.Context) (err error) {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest,
 			ErrorMessage("Invalid hex-encoded multihash representing of a peer ID"))
+	}
+
+	// Refuse to remove the peer while it is the active VPN gateway: doing so
+	// would leave the TUN default route / DNS installed with nothing bound and
+	// black-hole all non-local traffic. The user must disable gateway client
+	// mode first (an explicit, reversible action).
+	h.conf.RLock()
+	isActiveGateway := h.conf.VPNGateway.ClientEnabled && h.conf.VPNGateway.GatewayPeerID == req.PeerID
+	h.conf.RUnlock()
+	if isActiveGateway {
+		return c.JSON(http.StatusConflict,
+			ErrorMessage("disable VPN gateway before removing this peer"))
 	}
 
 	knownPeer, exists := h.conf.RemovePeer(req.PeerID)

--- a/application.go
+++ b/application.go
@@ -135,7 +135,7 @@ func (a *Application) Init(ctx context.Context, tunDevice tun.Device) error {
 		}
 		a.logger.Infof("VPN interface created. Name: %s CIDR: %s", interfaceName, &net.IPNet{IP: localIP, Mask: netMask})
 
-		a.Tunnel = service.NewTunnel(a.P2p, a.vpnDevice, a.Conf)
+		a.Tunnel = service.NewTunnel(a.P2p, a.vpnDevice, a.Conf, a.Eventbus)
 		go a.vpnDevice.ReadTUNPackets(a.Tunnel.HandleReadPackets)
 	}
 

--- a/application_gateway_test.go
+++ b/application_gateway_test.go
@@ -187,12 +187,17 @@ func TestGatewayPermissionDenied(t *testing.T) {
 	// Defence-in-depth on the exit-node side: silently flip WeAllow without
 	// going through the API (so the change does not propagate back to the
 	// client yet) and verify writeInboundBatch drops gateway-style packets.
+	// The hot-path permission check reads VpnPeer.weAllowUsingAsExitNode, an
+	// atomic kept in sync by RefreshPeersList; in production a settings change
+	// emits KnownPeerChanged which triggers it, so we call it directly here to
+	// mirror that local sync (the revocation still does not reach the client).
 	t.Run("DefenceInDepthDropsAtExitNode", func(t *testing.T) {
 		exitNode.app.Conf.Lock()
 		clientPeer := exitNode.app.Conf.KnownPeers[client.PeerID()]
 		clientPeer.WeAllowUsingAsExitNode = false
 		exitNode.app.Conf.KnownPeers[client.PeerID()] = clientPeer
 		exitNode.app.Conf.Unlock()
+		exitNode.app.Tunnel.RefreshPeersList()
 
 		captureInbound(exitNode, 10)
 
@@ -986,6 +991,41 @@ func TestGatewayRebindOnPeerReadd(t *testing.T) {
 	client.tun.Outbound <- [][]byte{packet}
 	_, ok = recvPacketWithTimeout(exitInbound)
 	ts.True(ok, "gateway should flow again after the peer is re-added")
+}
+
+// TestGatewayPeerRemovalRefusedWhileActive verifies the API refuses to remove
+// the configured gateway peer while client mode is ACTIVE. Allowing the removal
+// would leave the OS routes/DNS installed with nothing bound and black-hole all
+// non-local traffic until restart, so RemovePeer returns 409 and the user must
+// disable the gateway first. The peer and its gateway binding stay intact.
+func TestGatewayPeerRemovalRefusedWhileActive(t *testing.T) {
+	skipIfVPNGatewayUnsupported(t)
+	ts := NewTestSuite(t)
+	client, exitNode, _ := setupGatewayPeers(ts)
+
+	// Enable via the API so VPNGateway applies (stubbed) routes + config.
+	ts.NoError(client.api.EnableVPNGatewayClient(exitNode.PeerID()))
+	ts.True(client.app.VPNGateway.IsClientActive(), "precondition: client routes installed")
+
+	// Removing the active gateway peer must be rejected.
+	err := client.api.RemovePeer(exitNode.PeerID())
+	ts.Error(err, "removing the active gateway peer must be refused")
+	ts.Contains(err.Error(), "disable VPN gateway")
+
+	// The peer is still known and the gateway is still active and persisted.
+	_, ok := client.app.Conf.GetPeer(exitNode.PeerID())
+	ts.True(ok, "the gateway peer must remain in KnownPeers after a refused removal")
+	ts.True(client.app.VPNGateway.IsClientActive(), "gateway client mode must stay active")
+	client.app.Conf.RLock()
+	ts.True(client.app.Conf.VPNGateway.ClientEnabled, "ClientEnabled must stay persisted")
+	client.app.Conf.RUnlock()
+
+	// After disabling the gateway, removal succeeds.
+	ts.NoError(client.api.DisableVPNGatewayClient())
+	ts.NoError(client.api.RemovePeer(exitNode.PeerID()),
+		"removal must succeed once the gateway is disabled")
+	_, ok = client.app.Conf.GetPeer(exitNode.PeerID())
+	ts.False(ok, "the peer must be gone after removal")
 }
 
 // TestGatewayListAvailableGatewaysFiltersToVPNGatewayOnly verifies that

--- a/awlevent/awlevent.go
+++ b/awlevent/awlevent.go
@@ -18,6 +18,16 @@ type ReceivedAuthRequest struct {
 	PeerID string
 }
 
+// VPNGatewayConnectivityChanged is emitted (client mode only) when the
+// connection to the configured VPN gateway peer goes up or down, so the UI /
+// tray can reflect gateway reachability immediately instead of waiting for the
+// next GatewayInfo poll. GatewayInfo.Connected stays the canonical state; this
+// event is a low-latency edge signal, deduplicated to fire only on transitions.
+type VPNGatewayConnectivityChanged struct {
+	Connected bool
+	PeerID    string
+}
+
 func WrapSubscriptionToCallback(ctx context.Context, callback func(interface{}), bus Bus,
 	eventType interface{}, opts ...event.SubscriptionOpt) {
 	sub, err := bus.Subscribe(eventType, opts...)

--- a/cmd/awl-tray/main.go
+++ b/cmd/awl-tray/main.go
@@ -169,6 +169,28 @@ func subscribeToNotifications(app *awl.Application) {
 			logger.Errorf("show notification: incoming friend request: %v", notifyErr)
 		}
 	}, app.Eventbus, new(awlevent.ReceivedAuthRequest))
+
+	// VPN gateway reachability: notify the user when the connection to their
+	// selected VPN gateway peer goes up or down.
+	awlevent.WrapSubscriptionToCallback(app.Ctx(), func(evt interface{}) {
+		change := evt.(awlevent.VPNGatewayConnectivityChanged)
+		peerName := change.PeerID
+		if kp, ok := app.Conf.GetPeer(change.PeerID); ok {
+			peerName = kp.DisplayName()
+		}
+		var title, body string
+		if change.Connected {
+			title = "Anywherelan: VPN gateway connected"
+			body = fmt.Sprintf("Connected to: %s", peerName)
+		} else {
+			title = "Anywherelan: VPN gateway disconnected"
+			body = fmt.Sprintf("Lost connection to: %s", peerName)
+		}
+		notifyErr := beeep.Notify(title, body, embeds.GetIconPath())
+		if notifyErr != nil {
+			logger.Errorf("show notification: vpn gateway connectivity: %v", notifyErr)
+		}
+	}, app.Eventbus, new(awlevent.VPNGatewayConnectivityChanged))
 }
 
 func openWebGUI(a *awl.Application) error {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -270,7 +270,7 @@ definitions:
       gatewayPeerID:
         type: string
     required:
-      - gatewayPeerID
+    - gatewayPeerID
     type: object
   entity.FriendRequest:
     properties:
@@ -814,6 +814,10 @@ paths:
           description: Not Found
           schema:
             $ref: '#/definitions/api.Error'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/api.Error'
       summary: Remove known peer
       tags:
       - Peers
@@ -857,13 +861,13 @@ paths:
             $ref: '#/definitions/github_com_anywherelan_awl_config.Config'
       summary: Export server configuration
       tags:
-        - Settings
+      - Settings
   /settings/list_proxies:
     get:
       consumes:
-        - application/json
+      - application/json
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: OK
@@ -885,20 +889,20 @@ paths:
             $ref: '#/definitions/entity.PeerInfo'
       summary: Get my peer info
       tags:
-        - Settings
+      - Settings
   /settings/set_proxy:
     post:
       consumes:
-        - application/json
+      - application/json
       parameters:
-        - description: Params
-          in: body
-          name: body
-          required: true
-          schema:
-            $ref: '#/definitions/entity.UpdateProxySettingsRequest'
+      - description: Params
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/entity.UpdateProxySettingsRequest'
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: OK
@@ -927,40 +931,40 @@ paths:
   /vpn_gateway/client/disable:
     post:
       consumes:
-        - application/json
+      - application/json
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: OK
       summary: Disable VPN gateway client mode
       tags:
-        - VPN Gateway
+      - VPN Gateway
   /vpn_gateway/client/enable:
     post:
       consumes:
-        - application/json
+      - application/json
       parameters:
-        - description: Params
-          in: body
-          name: body
-          required: true
-          schema:
-            $ref: '#/definitions/entity.EnableVPNGatewayClientRequest'
+      - description: Params
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/entity.EnableVPNGatewayClientRequest'
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: OK
       summary: Enable VPN gateway client mode
       tags:
-        - VPN Gateway
+      - VPN Gateway
   /vpn_gateway/client/list_available:
     get:
       consumes:
-        - application/json
+      - application/json
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: OK
@@ -968,24 +972,24 @@ paths:
             $ref: '#/definitions/entity.ListAvailableVPNGatewaysResponse'
       summary: List available VPN gateways
       tags:
-        - VPN Gateway
+      - VPN Gateway
   /vpn_gateway/server/set_enabled:
     post:
       consumes:
-        - application/json
+      - application/json
       parameters:
-        - description: Params
-          in: body
-          name: body
-          required: true
-          schema:
-            $ref: '#/definitions/entity.SetVPNGatewayServerEnabledRequest'
+      - description: Params
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/entity.SetVPNGatewayServerEnabledRequest'
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: OK
       summary: Toggle VPN gateway server mode
       tags:
-        - VPN Gateway
+      - VPN Gateway
 swagger: "2.0"

--- a/service/auth_status.go
+++ b/service/auth_status.go
@@ -180,6 +180,10 @@ func (s *AuthStatus) createPeerInfo(peer config.KnownPeer, myPeerName string, de
 // the peer is no longer known.
 func (s *AuthStatus) processPeerStatusInfo(peerID string, peerInfo protocol.PeerStatusInfo) {
 	if peerInfo.Declined {
+		// TODO: emit an awlevent (analogous to VPNGatewayConnectivityChanged) when
+		//  a peer explicitly declines us, so the UI can surface it immediately. The
+		//  peer stays in KnownPeers as not-confirmed (including if it was our VPN
+		//  gateway — we keep the binding even though it will no longer forward).
 		s.conf.UpdatePeerFields(peerID, func(peer *config.KnownPeer) {
 			peer.LastSeen = time.Now()
 			peer.Declined = true
@@ -305,11 +309,9 @@ func (s *AuthStatus) SendAuthRequest(ctx context.Context, peerID peer.ID, req pr
 		s.authsLock.Unlock()
 	}
 	if authResponse.Declined {
-		knownPeer, exists := s.conf.GetPeer(peerID.String())
-		if exists {
-			knownPeer.Declined = true
-			s.conf.UpsertPeer(knownPeer)
-		}
+		s.conf.UpdatePeerFields(peerID.String(), func(peer *config.KnownPeer) {
+			peer.Declined = true
+		})
 	}
 
 	s.logger.Infof("Successfully send auth to %s", peerID)

--- a/service/tunnel.go
+++ b/service/tunnel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/anywherelan/awl/awlevent"
 	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/metrics"
 	"github.com/anywherelan/awl/protocol"
@@ -44,12 +45,24 @@ type Tunnel struct {
 	vpnGatewayServerEnabled bool     // server side: we serve as a VPN gateway for others
 	// awlSubnet is set once in NewTunnel and never mutated afterwards.
 	awlSubnet *net.IPNet
+
+	// gatewayConnEmitter emits awlevent.VPNGatewayConnectivityChanged. May be
+	// nil if the event bus had no emitter. vpnGatewayConnected holds the last
+	// emitted connectivity state so onPeerConnected/onPeerDisconnected only fire
+	// on real transitions (they run on every libp2p per-stream event).
+	gatewayConnEmitter  awlevent.Emitter
+	vpnGatewayConnected atomic.Bool
 }
 
-func NewTunnel(p2pService P2p, device *vpn.Device, conf *config.Config) *Tunnel {
+func NewTunnel(p2pService P2p, device *vpn.Device, conf *config.Config, eventbus awlevent.Bus) *Tunnel {
 	localIP, netMask := conf.VPNLocalIPMask()
 	awlSubnet := &net.IPNet{IP: localIP, Mask: netMask}
 	udpBroadcastAddr := vpn.GetIPv4BroadcastAddress(awlSubnet)
+
+	emitter, err := eventbus.Emitter(new(awlevent.VPNGatewayConnectivityChanged))
+	if err != nil {
+		panic(err)
+	}
 
 	tunnel := &Tunnel{
 		p2p:                     p2pService,
@@ -61,6 +74,7 @@ func NewTunnel(p2pService P2p, device *vpn.Device, conf *config.Config) *Tunnel 
 		udpBroadcastAddr:        udpBroadcastAddr,
 		vpnGatewayServerEnabled: conf.VPNGateway.ServerEnabled,
 		awlSubnet:               awlSubnet,
+		gatewayConnEmitter:      emitter,
 	}
 	tunnel.RefreshPeersList()
 	p2pService.SubscribeConnectionEvents(tunnel.onPeerConnected, tunnel.onPeerDisconnected)
@@ -188,6 +202,7 @@ func (t *Tunnel) RefreshPeersList() {
 			t.vpnGatewayClientEnabled = false
 			t.vpnGatewayPeerID = ""
 			t.vpnGatewayPeer = nil
+			t.vpnGatewayConnected.Store(false)
 		} else {
 			t.vpnGatewayPeer = gwPeer
 		}
@@ -505,7 +520,7 @@ func (vp *VpnPeer) backgroundInboundHandler(t *Tunnel) {
 		filteredPackets := packetsBatch[:newLen]
 
 		if len(filteredPackets) > 0 {
-			err := t.writeInboundBatch(filteredPackets, bytesBufs, localIP, vp.peerID)
+			err := t.writeInboundBatch(filteredPackets, bytesBufs, localIP, vp)
 			if err != nil {
 				t.logger.Warnf("write packets batch to vpn for local ip %s: %v", localIP, err)
 			} else {
@@ -580,6 +595,15 @@ func (t *Tunnel) SetVPNGatewayPeer(gatewayPeerID peer.ID) error {
 	t.conf.SaveLocked()
 	t.conf.Unlock()
 
+	// Seed connectivity from the current state and emit it, so the UI gets an
+	// immediate signal for the common case where the peer is not connected
+	// when the gateway is enabled.
+	connected := t.p2p.IsConnected(gatewayPeerID)
+	t.vpnGatewayConnected.Store(connected)
+	if !connected {
+		t.emitGatewayConnectivity(connected, gatewayPeerID)
+	}
+
 	return nil
 }
 
@@ -591,6 +615,7 @@ func (t *Tunnel) ClearVPNGatewayPeer() {
 	t.vpnGatewayClientEnabled = false
 	t.vpnGatewayPeerID = ""
 	t.vpnGatewayPeer = nil
+	t.vpnGatewayConnected.Store(false)
 
 	t.conf.Lock()
 	t.conf.VPNGateway.ClientEnabled = false
@@ -607,7 +632,12 @@ func (t *Tunnel) onPeerConnected(_ network.Network, conn network.Conn) {
 	if !enabled || gatewayPeerID == "" || conn.RemotePeer() != gatewayPeerID {
 		return
 	}
-	t.logger.Infof("VPN gateway peer %s connected", gatewayPeerID)
+	// libp2p fires this per connection; dedup so we emit only on the
+	// disconnected -> connected transition.
+	if t.vpnGatewayConnected.CompareAndSwap(false, true) {
+		t.logger.Infof("VPN gateway peer %s connected", gatewayPeerID)
+		t.emitGatewayConnectivity(true, gatewayPeerID)
+	}
 }
 
 func (t *Tunnel) onPeerDisconnected(_ network.Network, conn network.Conn) {
@@ -624,8 +654,23 @@ func (t *Tunnel) onPeerDisconnected(_ network.Network, conn network.Conn) {
 	if t.p2p.IsConnected(gatewayPeerID) {
 		return
 	}
-	t.logger.Warnf("VPN gateway peer %s disconnected", gatewayPeerID)
-	// TODO: emit an awlevent so the UI can show the VPN gateway peer is down
+	if t.vpnGatewayConnected.CompareAndSwap(true, false) {
+		t.logger.Warnf("VPN gateway peer %s disconnected", gatewayPeerID)
+		t.emitGatewayConnectivity(false, gatewayPeerID)
+	}
+}
+
+// emitGatewayConnectivity publishes a VPNGatewayConnectivityChanged edge event.
+// Best-effort: emit errors are non-fatal (GatewayInfo polling remains the
+// canonical source of truth).
+func (t *Tunnel) emitGatewayConnectivity(connected bool, gatewayPeerID peer.ID) {
+	if t.gatewayConnEmitter == nil {
+		return
+	}
+	_ = t.gatewayConnEmitter.Emit(awlevent.VPNGatewayConnectivityChanged{
+		Connected: connected,
+		PeerID:    gatewayPeerID.String(),
+	})
 }
 
 // writeInboundBatch rewrites IP headers per packet and writes the whole batch
@@ -649,29 +694,15 @@ func (t *Tunnel) onPeerDisconnected(_ network.Network, conn network.Conn) {
 // awl subnet inspection is intentionally absent here. The on-wire tag carries
 // the sender's intent explicitly, so this side does not need to re-derive it
 // from packet IPs and is not exposed to a subnet mismatch between peers.
-func (t *Tunnel) writeInboundBatch(packets []*vpn.Packet, bufs [][]byte, senderIP net.IP, remotePeerID peer.ID) error {
+func (t *Tunnel) writeInboundBatch(packets []*vpn.Packet, bufs [][]byte, senderIP net.IP, vp *VpnPeer) error {
 	t.peersLock.RLock()
 	serverEnabled := t.vpnGatewayServerEnabled
-	isOurGateway := t.vpnGatewayClientEnabled && remotePeerID == t.vpnGatewayPeerID
+	isOurGateway := t.vpnGatewayClientEnabled && vp.peerID == t.vpnGatewayPeerID
 	t.peersLock.RUnlock()
 
 	localIP := t.device.LocalIP()
 
-	// Lazy permission check: only resolved if we actually see a Forward
-	// packet, so the common case (no gateway role active) skips the
-	// peer.ID.String() allocation and the conf RLock.
-	var allowGateway, permResolved bool
-	isGatewayAllowed := func() bool {
-		if permResolved {
-			return allowGateway
-		}
-		// TODO: store this info in atomic in VpnPeer and update in RefreshPeersList
-		//  this will eliminate lock usage on every packets batch
-		kp, ok := t.conf.GetPeer(remotePeerID.String())
-		allowGateway = ok && kp.WeAllowUsingAsExitNode
-		permResolved = true
-		return allowGateway
-	}
+	allowGateway := vp.weAllowUsingAsExitNode.Load()
 
 	for _, packet := range packets {
 		if packet.IsIPv6 {
@@ -685,7 +716,7 @@ func (t *Tunnel) writeInboundBatch(packets []*vpn.Packet, bufs [][]byte, senderI
 				metrics.VPNPacketsDroppedTotal.WithLabelValues("gateway_server_disabled").Inc()
 				continue
 			}
-			if !isGatewayAllowed() {
+			if !allowGateway {
 				metrics.VPNPacketsDroppedTotal.WithLabelValues("gateway_not_allowed").Inc()
 				continue
 			}

--- a/vpn/routes/routes_linux.go
+++ b/vpn/routes/routes_linux.go
@@ -6,7 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
+	"sync/atomic"
 	"syscall"
+	"time"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -40,10 +43,16 @@ type RouteState struct {
 	tunLinkIndex int
 	fwmark       uint32
 
-	// origDefaults are the IPv4 default routes that existed before SetupGateway
-	// was called. They are NOT mutated; the new TUN default route is added
-	// alongside via RouteAdd, so teardown only has to remove what we added
-	// instead of restoring originals.
+	// mu guards origDefaults / origDefaultsV6, which the route-change monitor
+	// rewrites when the host default changes mid-session (see runRouteMonitor).
+	// The remaining fields are set once during setup and never mutated.
+	mu sync.Mutex
+
+	// origDefaults are the IPv4 default routes copied into tableID as the marked
+	// libp2p exemption path. Seeded from the main table at setup and then kept in
+	// sync with the live default(s) by the route-change monitor. teardown removes
+	// exactly this set from tableID. The TUN default route itself is separate
+	// (tunRouteAdded) and never appears here.
 	origDefaults  []netlink.Route
 	tunRouteAdded bool
 
@@ -51,10 +60,22 @@ type RouteState struct {
 	// leaking past the exit node on a dual-stack host we fence it with an
 	// `unreachable ::/0` route, and exempt marked libp2p sockets via a v6
 	// fwmark rule + a copy of the host's IPv6 default(s) into tableID. Mirrors
-	// the IPv4 fields above. origDefaultsV6 may be empty (host has no IPv6).
+	// the IPv4 fields above. origDefaultsV6 may be empty (host has no IPv6) and,
+	// like origDefaults, is kept current by the monitor.
 	origDefaultsV6 []netlink.Route
 	v6RuleAdded    bool
 	v6UnreachAdded bool
+
+	// Route-change monitor lifecycle. monitorDone is closed by
+	// TeardownGatewayRoutes to stop the monitor; monitorWG waits for the
+	// goroutine to finish before teardown mutates tableID. Both are zero/nil when
+	// no monitor is running (e.g. a rollback before startRouteMonitor).
+	// stopping is set just before monitorDone is closed so the subscription's
+	// ErrorCallback can suppress the benign "Receive failed" that our own
+	// socket close provokes (netlink never closes the socket itself on error).
+	monitorDone chan struct{}
+	monitorWG   sync.WaitGroup
+	stopping    atomic.Bool
 }
 
 // SetupGatewayRoutes configures the system to route all traffic through the
@@ -87,16 +108,14 @@ func SetupGatewayRoutes(tunIfName string, fwmark uint32) (*RouteState, error) {
 		logger.Warnf("recovered from leftover gateway route state (previous run was likely killed before teardown)")
 	}
 
-	// TODO(gateway-route-staleness): origDefaults (and origDefaultsV6 below) are
-	// snapshotted once here and copied into tableID; they are never refreshed.
-	// Applies to BOTH families. If the host default changes mid-session (IPv4:
-	// DHCP renew, Wi-Fi<->Ethernet roaming; IPv6: RA re-advertising a new
-	// router/prefix — far more frequent), the copy in tableID goes stale and
-	// marked libp2p sockets lose their physical-NIC exit until the gateway is
-	// re-toggled. This does NOT cause a leak — the catch-all TUN default / v6
-	// unreachable route is static — only degraded p2p connectivity. Fix:
-	// subscribe to netlink RTM_NEWROUTE/RTM_DELROUTE and re-copy the live
-	// default(s) into tableID for both families.
+	// origDefaults (and origDefaultsV6 below) are snapshotted here and copied
+	// into tableID as the marked-libp2p exemption path. If the host default
+	// changes mid-session (IPv4: DHCP renew, Wi-Fi<->Ethernet roaming; IPv6: RA
+	// re-advertising a new router/prefix — far more frequent), this copy would go
+	// stale and marked libp2p sockets would lose their physical-NIC exit. This is
+	// degraded p2p connectivity, never a leak — the catch-all TUN default / v6
+	// unreachable route is static. startRouteMonitor (called at the end of setup)
+	// subscribes to netlink route changes and re-syncs tableID for both families.
 	origDefaults, err := getDefaultRoutes()
 	if err != nil {
 		return nil, fmt.Errorf("get default routes: %w", err)
@@ -154,6 +173,12 @@ func SetupGatewayRoutes(tunIfName string, fwmark uint32) (*RouteState, error) {
 		_ = TeardownGatewayRoutes(state)
 		return nil, err
 	}
+
+	// Everything is in place: start tracking host default-route changes so the
+	// tableID exemption copies stay in sync with the live uplink. Started last so
+	// a rollback above never has to stop a monitor. A subscribe failure is
+	// non-fatal — the gateway still works, only staleness tracking is disabled.
+	state.startRouteMonitor()
 
 	return state, nil
 }
@@ -295,6 +320,11 @@ func TeardownGatewayRoutes(state *RouteState) error {
 	if state == nil {
 		return nil
 	}
+
+	// Stop the route-change monitor first and wait for it to exit, so it can't
+	// race with the tableID deletions below (it mutates the same table + the
+	// origDefaults slices). After this returns, we have exclusive access.
+	state.stopRouteMonitor()
 
 	var errs []error
 
@@ -477,4 +507,287 @@ func isIPv6DefaultDst(dst *net.IPNet) bool {
 	}
 	bits, _ := dst.Mask.Size()
 	return bits == 0
+}
+
+// routeMonitorDebounce is the interval at which the monitor checks whether any
+// relevant route event has arrived since the last reconcile. A single uplink
+// change (DHCP renew, Wi-Fi roam, new RA) emits a burst of
+// RTM_NEWROUTE/RTM_DELROUTE messages; the monitor only marks state dirty as they
+// come in and reconciles at most once per tick, coalescing the burst into a
+// single reconcile (bounded worst-case latency of one interval).
+// Our reconcile is two netlink dumps + a small
+// diff with no external consumers, so a short interval is fine — and the window
+// it bounds is only degraded p2p, never a leak, so faster restoration is a mild
+// plus.
+const routeMonitorDebounce = 500 * time.Millisecond
+
+// routeMonitorResubscribeBackoff is how long the monitor waits before retrying a
+// netlink subscription that died mid-session (see runRouteMonitor).
+const routeMonitorResubscribeBackoff = 1 * time.Second
+
+// startRouteMonitor subscribes to kernel route changes and keeps the tableID
+// exemption copies in sync with the live host default(s). Best-effort: if the
+// netlink subscription can't be established the gateway still works, only
+// staleness tracking is disabled. Call exactly once, at the end of a successful
+// SetupGatewayRoutes.
+func (s *RouteState) startRouteMonitor() {
+	teardownDone := make(chan struct{})
+	subDone := make(chan struct{})
+	updates, err := s.subscribeRouteUpdates(subDone)
+	if err != nil {
+		// Initial subscription failed: give up (unlike a mid-session death, which
+		// runRouteMonitor retries). Best-effort — the gateway still works, only
+		// staleness tracking is disabled.
+		logger.Warnf("gateway route monitor: subscribe failed, route-staleness tracking disabled: %v", err)
+		return
+	}
+
+	s.monitorDone = teardownDone
+	s.monitorWG.Add(1)
+	go s.runRouteMonitor(updates, subDone, teardownDone)
+}
+
+// subscribeRouteUpdates opens a fresh netlink route-change subscription feeding a
+// new updates channel. Closing subDone tears down THIS subscription's socket and
+// its internal watcher goroutine — the library never closes the socket itself on
+// a receive error, so each subscription needs its own cancel channel to avoid
+// leaking a socket + goroutine per re-subscription. netlink closes the updates
+// channel on any receive error, which the consumer treats as "subscription died".
+// The ErrorCallback stays quiet once s.stopping is set: tearing our own socket
+// down provokes a benign "Receive failed" that is not worth logging.
+func (s *RouteState) subscribeRouteUpdates(subDone <-chan struct{}) (chan netlink.RouteUpdate, error) {
+	updates := make(chan netlink.RouteUpdate, 64)
+	opts := netlink.RouteSubscribeOptions{
+		ListExisting: false,
+		ErrorCallback: func(err error) {
+			if s.stopping.Load() {
+				return
+			}
+			logger.Warnf("gateway route monitor: %v", err)
+		},
+	}
+	if err := netlink.RouteSubscribeWithOptions(updates, subDone, opts); err != nil {
+		return nil, err
+	}
+	return updates, nil
+}
+
+// stopRouteMonitor signals the monitor to stop and blocks until it has exited,
+// guaranteeing the caller exclusive access to the tableID state afterwards.
+// Idempotent and safe when no monitor is running.
+func (s *RouteState) stopRouteMonitor() {
+	if s.monitorDone == nil {
+		return
+	}
+	// Set before closing so the ErrorCallback suppresses the benign "Receive
+	// failed" that runRouteMonitor's deferred close(subDone) will provoke.
+	s.stopping.Store(true)
+	close(s.monitorDone)
+	s.monitorWG.Wait()
+	s.monitorDone = nil
+}
+
+// runRouteMonitor consumes route-change events and reconciles tableID after a
+// debounce window. It exits only when teardownDone is closed (via
+// stopRouteMonitor); a mid-session subscription death (netlink socket error →
+// updates closed) is recovered by re-subscribing rather than giving up, so
+// staleness tracking survives transient netlink failures.
+//
+// subDone is the live subscription's cancel channel. It is closed (and replaced)
+// on every re-subscription and once more on exit, so no dead subscription's
+// socket or watcher goroutine outlives the event that killed it.
+func (s *RouteState) runRouteMonitor(updates <-chan netlink.RouteUpdate, subDone chan struct{}, teardownDone <-chan struct{}) {
+	defer s.monitorWG.Done()
+	// Tears down whichever subscription is live when we exit. The closure reads
+	// the current subDone, which the loop reassigns on each re-subscription.
+	defer func() { close(subDone) }()
+
+	ticker := time.NewTicker(routeMonitorDebounce)
+	defer ticker.Stop()
+
+	dirty := false
+	for {
+		select {
+		case upd, ok := <-updates:
+			if !ok {
+				// Subscription died mid-session. Release the dead subscription's
+				// socket + watcher goroutine, then re-subscribe on a fresh socket
+				// and force a catch-up reconcile (events may have been missed while
+				// it was down). Bail only if we were stopped during backoff.
+				close(subDone)
+				subDone = make(chan struct{})
+				newUpdates, ok := s.resubscribe(subDone, teardownDone)
+				if !ok {
+					return
+				}
+				updates = newUpdates
+				dirty = true
+				continue
+			}
+			if isDefaultRouteUpdate(upd) {
+				dirty = true
+			}
+		case <-ticker.C:
+			if dirty {
+				dirty = false
+				s.reconcile()
+			}
+		case <-teardownDone:
+			return
+		}
+	}
+}
+
+// resubscribe retries the netlink subscription after a mid-session death, with a
+// backoff between attempts. It returns the new updates channel, or ok=false if
+// teardownDone was closed (teardown) while waiting/retrying. All attempts share
+// subDone: a failed subscribe binds nothing, so reuse leaks nothing, and the one
+// that succeeds binds its socket to subDone for the caller to cancel later.
+func (s *RouteState) resubscribe(subDone <-chan struct{}, teardownDone <-chan struct{}) (<-chan netlink.RouteUpdate, bool) {
+	for {
+		select {
+		case <-teardownDone:
+			return nil, false
+		case <-time.After(routeMonitorResubscribeBackoff):
+		}
+
+		updates, err := s.subscribeRouteUpdates(subDone)
+		if err != nil {
+			logger.Warnf("gateway route monitor: re-subscribe failed, retrying in %s: %v", routeMonitorResubscribeBackoff, err)
+			continue
+		}
+		logger.Infof("gateway route monitor: re-subscribed after subscription loss")
+		return updates, true
+	}
+}
+
+// reconcile brings the tableID exemption copies back in line with the live host
+// default routes for both families. It NEVER touches the TUN default route or
+// the IPv6 unreachable fence (those are the static catch-all that guarantees no
+// leak) — it only adjusts the marked-libp2p exemption path.
+func (s *RouteState) reconcile() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if newV4, err := s.liveExemptionDefaults(netlink.FAMILY_V4); err != nil {
+		logger.Warnf("gateway route monitor: list IPv4 defaults: %v", err)
+	} else {
+		s.reconcileTableLocked(&s.origDefaults, newV4, "IPv4")
+	}
+
+	// Only reconcile IPv6 when the fence/exemption path is actually installed
+	// (a host with a kernel-level disabled IPv6 stack leaves v6RuleAdded false).
+	if s.v6RuleAdded {
+		if newV6, err := s.liveExemptionDefaults(netlink.FAMILY_V6); err != nil {
+			if !ipv6Unavailable(err) {
+				logger.Warnf("gateway route monitor: list IPv6 defaults: %v", err)
+			}
+		} else {
+			s.reconcileTableLocked(&s.origDefaultsV6, newV6, "IPv6")
+		}
+	}
+}
+
+// liveExemptionDefaults returns the current main-table default routes for the
+// given family that belong in the exemption table, excluding awl's own routes
+// (the TUN default and the IPv6 unreachable fence) so we never copy them into
+// tableID — doing so would route marked sockets back into the TUN.
+func (s *RouteState) liveExemptionDefaults(family int) ([]netlink.Route, error) {
+	var (
+		all []netlink.Route
+		err error
+	)
+	if family == netlink.FAMILY_V6 {
+		all, err = getDefaultRoutesV6()
+	} else {
+		all, err = getDefaultRoutes()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]netlink.Route, 0, len(all))
+	for i := range all {
+		r := all[i]
+		if r.LinkIndex == s.tunLinkIndex {
+			continue // our TUN default route — never an exemption
+		}
+		if r.Type == unix.RTN_UNREACHABLE || r.Type == unix.RTN_BLACKHOLE {
+			continue // our IPv6 fence (or any non-forwarding default)
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// reconcileTableLocked diffs the currently-recorded exemption copies against the
+// desired live set (both keyed by routeKey) and applies the delta to tableID:
+// removing copies whose default disappeared and adding copies for defaults that
+// appeared. current is updated to desired. Must hold s.mu.
+func (s *RouteState) reconcileTableLocked(current *[]netlink.Route, desired []netlink.Route, family string) {
+	oldByKey := make(map[string]netlink.Route, len(*current))
+	for _, r := range *current {
+		oldByKey[routeKey(r)] = r
+	}
+	newByKey := make(map[string]netlink.Route, len(desired))
+	for _, r := range desired {
+		newByKey[routeKey(r)] = r
+	}
+
+	// changed tracks whether we actually mutated tableID, so the summary log
+	// below reflects a real re-sync. It is set only when the netlink op succeeds:
+	// a failed RouteDel/RouteAdd already logs its own warning and must not be
+	// reported as a successful re-sync.
+	changed := false
+	for k, r := range oldByKey {
+		if _, ok := newByKey[k]; ok {
+			continue
+		}
+		tableRoute := r
+		tableRoute.Table = tableID
+		if err := netlink.RouteDel(&tableRoute); err != nil {
+			logger.Warnf("gateway route monitor: remove stale %s default from table %d: %v", family, tableID, err)
+			continue
+		}
+		changed = true
+	}
+	for k, r := range newByKey {
+		if _, ok := oldByKey[k]; ok {
+			continue
+		}
+		tableRoute := r
+		tableRoute.Table = tableID
+		if err := netlink.RouteAdd(&tableRoute); err != nil {
+			logger.Warnf("gateway route monitor: add %s default to table %d: %v", family, tableID, err)
+			continue
+		}
+		changed = true
+	}
+
+	// Record the desired set as the new baseline so teardown removes exactly it,
+	// even if an individual RouteAdd/RouteDel above failed (best-effort; a stray
+	// leftover is swept by cleanupStaleRoutes on the next setup).
+	*current = desired
+	if changed {
+		logger.Infof("gateway route monitor: re-synced %s default(s) in table %d after a host route change", family, tableID)
+	}
+}
+
+// isDefaultRouteUpdate reports whether a route event concerns a main-table
+// default route (either family). Changes in other tables — including awl's own
+// tableID edits — are ignored, so reconcile never triggers itself.
+func isDefaultRouteUpdate(upd netlink.RouteUpdate) bool {
+	r := upd.Route
+	if r.Table != unix.RT_TABLE_MAIN {
+		return false
+	}
+	return isIPv4DefaultDst(r.Dst) || isIPv6DefaultDst(r.Dst)
+}
+
+// routeKey identifies a default route by its forwarding attributes (the Dst is
+// always the default, so it is omitted). Two routes with the same key are the
+// same exemption path; a change in any of these fields is a real uplink change
+// that reconcile must mirror into tableID.
+func routeKey(r netlink.Route) string {
+	return fmt.Sprintf("%d|%s|%s|%d", r.LinkIndex, r.Gw, r.Src, r.Priority)
 }

--- a/vpn/routes/vpn_hostnet_integration_test.go
+++ b/vpn/routes/vpn_hostnet_integration_test.go
@@ -40,9 +40,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"go.uber.org/goleak"
 
 	"github.com/anywherelan/awl/vpn/sockmark"
 )
@@ -58,6 +60,7 @@ func testFWMark() uint32 { return sockmark.New().FWMark() }
 // ---- N1: NAT apply/teardown lifecycle ----
 
 func TestGatewayHostNetNATLifecycle(t *testing.T) {
+	verifyNoLeaks(t)
 	requireRoot(t)
 	setupDummyTun(t)
 	origForward := captureForward(t)
@@ -84,6 +87,7 @@ func TestGatewayHostNetNATLifecycle(t *testing.T) {
 // succeeds and the resulting state is identical to a single clean setup.
 
 func TestGatewayHostNetNATIdempotentResetup(t *testing.T) {
+	verifyNoLeaks(t)
 	requireRoot(t)
 	setupDummyTun(t)
 	captureForward(t)
@@ -109,6 +113,7 @@ func TestGatewayHostNetNATIdempotentResetup(t *testing.T) {
 // ---- N3: NAT leaves a pre-existing ip_forward=1 untouched ----
 
 func TestGatewayHostNetNATPreservesExistingIPForward(t *testing.T) {
+	verifyNoLeaks(t)
 	requireRoot(t)
 	setupDummyTun(t)
 	captureForward(t)
@@ -129,6 +134,7 @@ func TestGatewayHostNetNATPreservesExistingIPForward(t *testing.T) {
 // ---- R1: route apply/teardown lifecycle ----
 
 func TestGatewayHostNetRoutesLifecycle(t *testing.T) {
+	verifyNoLeaks(t)
 	requireRoot(t)
 	requireDefaultRoute(t)
 	setupDummyTun(t)
@@ -152,15 +158,22 @@ func TestGatewayHostNetRoutesLifecycle(t *testing.T) {
 // and succeed without an EEXIST on the new TUN default.
 
 func TestGatewayHostNetRoutesStaleRecovery(t *testing.T) {
+	verifyNoLeaks(t)
 	requireRoot(t)
 	requireDefaultRoute(t)
 	setupDummyTun(t)
 
 	before := snapshotNet(t)
 
-	_, err := SetupGatewayRoutes(testTunIf, testFWMark())
+	state1, err := SetupGatewayRoutes(testTunIf, testFWMark())
 	require.NoError(t, err)
 	applied1 := snapshotNet(t)
+
+	// Simulate the crash: the first run's monitor goroutine would die with its
+	// process. Stop just the monitor (no OS teardown — the routes/rule/table are
+	// left orphaned on purpose for cleanupStaleRoutes to recover) before the
+	// recovery, so it neither leaks nor races the second setup.
+	state1.stopRouteMonitor()
 
 	// Simulate the TUN dying: deleting awl0 makes the kernel auto-remove the
 	// default route via it, leaving the fwmark rule + table copies orphaned.
@@ -183,6 +196,7 @@ func TestGatewayHostNetRoutesStaleRecovery(t *testing.T) {
 // duplicating or clobbering.
 
 func TestGatewayHostNetRoutesLeftoverTunRouteErrors(t *testing.T) {
+	verifyNoLeaks(t)
 	requireRoot(t)
 	requireDefaultRoute(t)
 	setupDummyTun(t)
@@ -204,6 +218,109 @@ func TestGatewayHostNetRoutesLeftoverTunRouteErrors(t *testing.T) {
 
 	require.NoError(t, netlink.RouteDel(leftover))
 	require.Equal(t, before, snapshotNet(t), "the failed setup must leave no partial state behind")
+}
+
+// ---- R4: route-change monitor keeps the exemption table in sync ----
+//
+// After setup, the monitor (netlink RTM_NEWROUTE/DELROUTE subscription) must
+// mirror host default-route changes into tableID so marked libp2p sockets keep
+// a physical-NIC exit across a DHCP renew / uplink roam. Here we simulate a new
+// uplink by adding a second default via a dummy interface into the main table,
+// then removing it, asserting the awl table follows both edges. It must never
+// disturb the TUN default route or the IPv6 fence.
+func TestGatewayHostNetRoutesStalenessReconcile(t *testing.T) {
+	verifyNoLeaks(t)
+	requireRoot(t)
+	requireDefaultRoute(t)
+	setupDummyTun(t)
+
+	state, err := SetupGatewayRoutes(testTunIf, testFWMark())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = TeardownGatewayRoutes(state) })
+
+	// A second dummy "uplink" with an on-link subnet and its own default route,
+	// at a high metric so it never competes with real egress or the TUN default.
+	const dummy2 = "awldummy2"
+	_ = exec.Command("ip", "link", "del", dummy2).Run() // best-effort pre-clean
+	mustCmd(t, "ip", "link", "add", dummy2, "type", "dummy")
+	mustCmd(t, "ip", "link", "set", dummy2, "up")
+	mustCmd(t, "ip", "addr", "add", "192.0.2.1/24", "dev", dummy2)
+	t.Cleanup(func() { _ = exec.Command("ip", "link", "del", dummy2).Run() })
+
+	mustCmd(t, "ip", "route", "add", "default", "via", "192.0.2.2", "dev", dummy2, "metric", "4000")
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(routeTableDump(t, tableID), "dev "+dummy2)
+	}, 5*time.Second, 100*time.Millisecond,
+		"the monitor must copy the new host default into the awl exemption table")
+
+	// The TUN default and IPv6 fence must be untouched by the reconcile.
+	assertRoutesApplied(t)
+
+	// Remove the second default; the awl table copy must follow.
+	mustCmd(t, "ip", "route", "del", "default", "via", "192.0.2.2", "dev", dummy2, "metric", "4000")
+
+	require.Eventually(t, func() bool {
+		return !strings.Contains(routeTableDump(t, tableID), "dev "+dummy2)
+	}, 5*time.Second, 100*time.Millisecond,
+		"the monitor must remove the stale default from the awl exemption table")
+
+	// The remove edge, like the add edge, must leave the TUN default and IPv6
+	// fence intact — reconcile only ever adjusts the exemption copies.
+	assertRoutesApplied(t)
+}
+
+// ---- R5: IPv6 route-change monitor keeps the exemption table in sync ----
+//
+// The IPv6 counterpart of R4. RA re-advertising a new router/prefix changes the
+// v6 default far more often than IPv4 changes, so the monitor must mirror v6
+// default changes into tableID too (marked libp2p v6 sockets otherwise fall
+// through to the `unreachable ::/0` fence and get EHOSTUNREACH). We simulate a
+// new v6 uplink with a high-metric default via a dummy interface and assert the
+// awl table follows both edges without disturbing the fence or the TUN default.
+func TestGatewayHostNetRoutesStalenessReconcileV6(t *testing.T) {
+	verifyNoLeaks(t)
+	requireRoot(t)
+	requireDefaultRoute(t)
+	// The v6 fence/exemption path (and thus v6 reconcile) only exists when the
+	// IPv6 stack is present; a kernel-level disable (ipv6.disable=1) removes it.
+	if _, err := os.Stat("/proc/sys/net/ipv6"); os.IsNotExist(err) {
+		t.Skip("no IPv6 stack on this host; the v6 exemption path is not installed")
+	}
+	setupDummyTun(t)
+
+	state, err := SetupGatewayRoutes(testTunIf, testFWMark())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = TeardownGatewayRoutes(state) })
+
+	// A second dummy "uplink" with an on-link v6 subnet and its own v6 default,
+	// at a high metric so it never competes with real egress or the fence.
+	const dummy2 = "awldummy2"
+	_ = exec.Command("ip", "link", "del", dummy2).Run() // best-effort pre-clean
+	mustCmd(t, "ip", "link", "add", dummy2, "type", "dummy")
+	mustCmd(t, "ip", "link", "set", dummy2, "up")
+	mustCmd(t, "ip", "addr", "add", "2001:db8::1/64", "dev", dummy2, "nodad")
+	t.Cleanup(func() { _ = exec.Command("ip", "link", "del", dummy2).Run() })
+
+	mustCmd(t, "ip", "-6", "route", "add", "default", "via", "2001:db8::2", "dev", dummy2, "metric", "4000")
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(route6TableDump(t, tableID), "dev "+dummy2)
+	}, 5*time.Second, 100*time.Millisecond,
+		"the monitor must copy the new host IPv6 default into the awl exemption table")
+
+	// The unreachable fence and TUN default must be untouched by the reconcile.
+	assertRoutesApplied(t)
+
+	// Remove the second v6 default; the awl table copy must follow.
+	mustCmd(t, "ip", "-6", "route", "del", "default", "via", "2001:db8::2", "dev", dummy2, "metric", "4000")
+
+	require.Eventually(t, func() bool {
+		return !strings.Contains(route6TableDump(t, tableID), "dev "+dummy2)
+	}, 5*time.Second, 100*time.Millisecond,
+		"the monitor must remove the stale IPv6 default from the awl exemption table")
+
+	assertRoutesApplied(t)
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +432,19 @@ func stripVolatile(s string) string {
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
+
+// verifyNoLeaks asserts the test spawns no goroutine that outlives it — chiefly
+// the route-change monitor and its netlink watcher goroutines, which
+// TeardownGatewayRoutes must reap. Registered via t.Cleanup (not defer) and as
+// the FIRST thing each test does, so — t.Cleanup being LIFO — it runs LAST,
+// after every teardown/link-delete cleanup, once nothing legitimate is left
+// running. IgnoreCurrent snapshots pre-existing background goroutines (logging
+// etc.) so only goroutines started by the test itself are held against it.
+func verifyNoLeaks(t *testing.T) {
+	t.Helper()
+	ignore := goleak.IgnoreCurrent()
+	t.Cleanup(func() { goleak.VerifyNone(t, ignore) })
+}
 
 func requireRoot(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
Route-staleness monitor (routes_linux.go): subscribe to netlink route changes and re-sync the tableID exemption copies (v4 and v6) with the live host default(s) on DHCP renew / Wi-Fi<->Ethernet roam / new RA. Debounced (500ms) reconcile diffs by route key; it never touches the TUN default or the IPv6 unreachable fence, so there is no leak window even mid-uplink-change. The monitor re-subscribes with backoff on a mid-session netlink socket death, using a per-subscription cancel channel so a dead socket + its watcher goroutine are released immediately rather than leaked. RouteState gains a mutex + monitor lifecycle; teardown stops the monitor first. Adds vpn_hostnet integration tests (v4 + v6 reconcile) with goleak checks.

Drop the conf lock on the inbound hot path: writeInboundBatch takes *VpnPeer and reads vp.weAllowUsingAsExitNode (atomic, synced by RefreshPeersList) instead of a per-batch conf.GetPeer RLock + peer.ID.String() alloc. Forward-without-permission is still dropped before the TUN write.

Gateway connectivity event: new awlevent.VPNGatewayConnectivityChanged, emitted from Tunnel on gateway-peer connect/disconnect with edge dedup and an initial state on enable. awl-tray shows a desktop notification on up/down.

Refuse removing a peer that is the active VPN gateway (409) instead of black-holing all non-local traffic; the user must disable the gateway first.