### PR TITLE
awldns: fix AAAA queries returning A records

### DIFF
--- a/awldns/awldns.go
+++ b/awldns/awldns.go
@@ -165,23 +165,29 @@ func (r *Resolver) dnsLocalDomainHandler(resp dns.ResponseWriter, req *dns.Msg) 
 		mappedIP, found := cfg.directMapping[hostnameLower]
 
 		switch qtype {
-		case dns.TypeA, dns.TypeAAAA, dns.TypeANY:
-			aRec := &dns.A{
-				Hdr: dns.RR_Header{
-					// we should return original name from the request as some clients expect that
-					Name:   hostname,
-					Rrtype: dns.TypeA,
-					Class:  dns.ClassINET,
-					Ttl:    defaultTTLSeconds,
-				},
-			}
-			if found {
-				// TODO: support ipv6
-				aRec.A = net.ParseIP(mappedIP).To4()
-			} else {
+		case dns.TypeA, dns.TypeANY:
+			if !found {
 				m.SetRcode(req, dns.RcodeNameError)
+				continue
 			}
-			m.Answer = append(m.Answer, aRec)
+			if ip := net.ParseIP(mappedIP).To4(); ip != nil {
+				m.Answer = append(m.Answer, &dns.A{
+					Hdr: dns.RR_Header{
+						// we should return original name from the request as some clients expect that
+						Name:   hostname,
+						Rrtype: dns.TypeA,
+						Class:  dns.ClassINET,
+						Ttl:    defaultTTLSeconds,
+					},
+					A: ip,
+				})
+			}
+		case dns.TypeAAAA:
+			if !found {
+				m.SetRcode(req, dns.RcodeNameError)
+				continue
+			}
+			// TODO: support IPv6 addresses in cfg.directMapping.
 		}
 	}
 

--- a/awldns/awldns_test.go
+++ b/awldns/awldns_test.go
@@ -68,6 +68,77 @@ func TestDNS(t *testing.T) {
 	}
 }
 
+func TestDNSAAAAQueryDoesNotReturnARecord(t *testing.T) {
+	a := require.New(t)
+	port := FindFreePort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	resolver := NewResolver(addr)
+	defer resolver.Close()
+	// TODO: remove sleep. We need it because NewResolver starts servers in goroutines
+	time.Sleep(50 * time.Millisecond)
+
+	resolver.ReceiveConfiguration("", map[string]string{
+		"admin": "127.0.0.66",
+	})
+
+	req := new(dns.Msg)
+	req.SetQuestion("admin.awl.", dns.TypeAAAA)
+	resp, _, err := new(dns.Client).Exchange(req, addr)
+	a.NoError(err)
+	a.Equal(dns.RcodeSuccess, resp.Rcode)
+	a.Empty(resp.Answer)
+}
+
+func TestDNSAQueryReturnsARecord(t *testing.T) {
+	a := require.New(t)
+	port := FindFreePort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	resolver := NewResolver(addr)
+	defer resolver.Close()
+	// TODO: remove sleep. We need it because NewResolver starts servers in goroutines
+	time.Sleep(50 * time.Millisecond)
+
+	resolver.ReceiveConfiguration("", map[string]string{
+		"admin": "127.0.0.66",
+	})
+
+	req := new(dns.Msg)
+	req.SetQuestion("admin.awl.", dns.TypeA)
+	resp, _, err := new(dns.Client).Exchange(req, addr)
+	a.NoError(err)
+	a.Equal(dns.RcodeSuccess, resp.Rcode)
+	a.Len(resp.Answer, 1)
+
+	aRecord, ok := resp.Answer[0].(*dns.A)
+	a.True(ok)
+	a.Equal("admin.awl.", aRecord.Hdr.Name)
+	a.Equal("127.0.0.66", aRecord.A.String())
+}
+
+func TestDNSUnknownAddressReturnsNameError(t *testing.T) {
+	a := require.New(t)
+	port := FindFreePort()
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	resolver := NewResolver(addr)
+	defer resolver.Close()
+	// TODO: remove sleep. We need it because NewResolver starts servers in goroutines
+	time.Sleep(50 * time.Millisecond)
+
+	resolver.ReceiveConfiguration("", map[string]string{
+		"admin": "127.0.0.66",
+	})
+
+	req := new(dns.Msg)
+	req.SetQuestion("unknown.awl.", dns.TypeA)
+	resp, _, err := new(dns.Client).Exchange(req, addr)
+	a.NoError(err)
+	a.Equal(dns.RcodeNameError, resp.Rcode)
+	a.Empty(resp.Answer)
+}
+
 func NewResolverClient(address string) *net.Resolver {
 	dialer := &net.Dialer{Timeout: time.Second}
 	return &net.Resolver{


### PR DESCRIPTION
## Summary
- Split local DNS response handling so A and AAAA queries only return matching record types.
- Keep IPv4-only mappings from returning A records for AAAA queries.
- Add a regression test for an `admin.awl` AAAA lookup.

## Root cause
The local DNS handler grouped `TypeA`, `TypeAAAA`, and `TypeANY` in the same branch, then always appended a `dns.A` record. That meant an AAAA query for an IPv4-mapped name could receive an A record in the answer section.

## Testing
- `./build.sh deps`
- `GOMAXPROCS=1 go test -p 1 ./awldns -count=1 -v`
- `GOMAXPROCS=1 go test -p 1 ./... -count=1 -v`

Fixes #150