### PR TITLE
all: use patched wf fork to fix Windows crash

### DIFF
--- a/cmd/awl-tray/go.mod
+++ b/cmd/awl-tray/go.mod
@@ -8,6 +8,7 @@ replace (
 	github.com/haxii/socks5 => github.com/anywherelan/socks5 v0.0.0-20260412023451-3f08306d7836
 	github.com/ipfs/go-log/v2 => github.com/anywherelan/go-log/v2 v2.0.3-0.20221101180049-46e3967f6fe5
 	github.com/ncruces/zenity => github.com/pymq/zenity v0.0.0-20230509161854-c117c448544d
+	github.com/tailscale/wf => github.com/anywherelan/wf v0.0.0-20260713071430-43b9c6827b85
 )
 
 require (

--- a/cmd/awl-tray/go.sum
+++ b/cmd/awl-tray/go.sum
@@ -62,6 +62,8 @@ github.com/anywherelan/systray v0.0.0-20260510040438-3aca44ed441f h1:mBpQubvgLNl
 github.com/anywherelan/systray v0.0.0-20260510040438-3aca44ed441f/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 github.com/anywherelan/ts-dns v0.0.0-20240721135326-6d6b7b811853 h1:RVKWGnppAfxgD2wphkq+OYDOqqI8zgbymBLl2pxYKzY=
 github.com/anywherelan/ts-dns v0.0.0-20240721135326-6d6b7b811853/go.mod h1:ly7HpPle1G3D0jwrr12uolTGWKN3DPgxzBYNR086BLo=
+github.com/anywherelan/wf v0.0.0-20260713071430-43b9c6827b85 h1:mGpcwlvF/MQH7SD5/K8q4NKe4RqMcNSp4hKsiFvDU28=
+github.com/anywherelan/wf v0.0.0-20260713071430-43b9c6827b85/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -533,8 +535,6 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af h1:6yITBqGTE2lEeTPG04SN9W+iWHCRyHqlVYILiSXziwk=
 github.com/tadvi/systray v0.0.0-20190226123456-11a2b8fa57af/go.mod h1:4F09kP5F+am0jAwlQLddpoMDM+iewkxxt6nxUQ5nq5o=
-github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
-github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 replace (
 	github.com/haxii/socks5 => github.com/anywherelan/socks5 v0.0.0-20260412023451-3f08306d7836
 	github.com/ipfs/go-log/v2 => github.com/anywherelan/go-log/v2 v2.0.3-0.20221101180049-46e3967f6fe5
+	github.com/tailscale/wf => github.com/anywherelan/wf v0.0.0-20260713071430-43b9c6827b85
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/anywherelan/socks5 v0.0.0-20260412023451-3f08306d7836 h1:RCZ6EfWrhzIL
 github.com/anywherelan/socks5 v0.0.0-20260412023451-3f08306d7836/go.mod h1:KpbKhNH2RqojJGPVT9faDXnYWkqzfgpKeehC8xTKaeY=
 github.com/anywherelan/ts-dns v0.0.0-20240721135326-6d6b7b811853 h1:RVKWGnppAfxgD2wphkq+OYDOqqI8zgbymBLl2pxYKzY=
 github.com/anywherelan/ts-dns v0.0.0-20240721135326-6d6b7b811853/go.mod h1:ly7HpPle1G3D0jwrr12uolTGWKN3DPgxzBYNR086BLo=
+github.com/anywherelan/wf v0.0.0-20260713071430-43b9c6827b85 h1:mGpcwlvF/MQH7SD5/K8q4NKe4RqMcNSp4hKsiFvDU28=
+github.com/anywherelan/wf v0.0.0-20260713071430-43b9c6827b85/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -493,8 +495,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
-github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=


### PR DESCRIPTION
Fixes "fatal error: bulkBarrierPreWrite: unaligned arguments" on Windows, introduced by https://github.com/anywherelan/awl/pull/250 , which added VPN gateway support for Windows.

The issue is reliably reproducible in CI:
https://github.com/anywherelan/awl/actions/runs/29185912454/job/86762894939#step:6:365
https://github.com/anywherelan/awl/actions/runs/29185912454/job/86633092986#step:10:36

Upstream fix: https://github.com/tailscale/wf/pull/30