### PR TITLE
cli: rework `me status` and `gateway status` output

### DIFF
--- a/cli/gateway.go
+++ b/cli/gateway.go
@@ -15,18 +15,26 @@ func gatewayStatus(api *apiclient.Client, w io.Writer) error {
 	}
 	gw := info.VPNGateway
 
-	fmt.Fprintf(w, "VPN gateway client enabled: %v\n", gw.ClientEnabled)
-	fmt.Fprintf(w, "VPN gateway server enabled: %v\n", gw.ServerEnabled)
+	line := func(label, value string) {
+		fmt.Fprintf(w, "%-14s %s\n", label+":", value)
+	}
+
+	line("Server", formatEnabled(gw.ServerEnabled))
+	line("Client", formatEnabled(gw.ClientEnabled))
 	if gw.ClientEnabled {
-		fmt.Fprintf(w, "Gateway peer:               %s (%s)\n", gw.GatewayPeerName, gw.GatewayPeerID)
-		fmt.Fprintf(w, "Gateway peer connected:     %v\n", gw.Connected)
+		name := gw.GatewayPeerName
+		if name == "" {
+			name = gw.GatewayPeerID
+		}
+		line("Gateway peer", fmt.Sprintf("%s [%s]", name, formatConnected(gw.Connected)))
+		line("Peer ID", gw.GatewayPeerID)
 		if gw.GatewayPublicIP != "" {
-			fmt.Fprintf(w, "Gateway public IP:          %s\n", gw.GatewayPublicIP)
+			line("Public IP", gw.GatewayPublicIP)
 		}
 		if gw.GatewayPing > 0 {
-			fmt.Fprintf(w, "Gateway ping:               %s\n", gw.GatewayPing.Round(time.Millisecond))
+			line("Ping", gw.GatewayPing.Round(time.Millisecond).String())
 		}
-		fmt.Fprintf(w, "Gateway via relay:          %v\n", gw.GatewayThroughRelay)
+		line("Connection", formatRelay(gw.GatewayThroughRelay))
 	}
 
 	return nil

--- a/cli/me.go
+++ b/cli/me.go
@@ -20,33 +20,41 @@ func printStatus(api *apiclient.Client, w io.Writer) error {
 	}
 
 	rows := [][]string{
+		{"Name", stats.Name},
 		{"Download rate", fmt.Sprintf("%s (%s)", stats.NetworkStatsInIECUnits.RateIn, stats.NetworkStatsInIECUnits.TotalIn)},
 		{"Upload rate", fmt.Sprintf("%s (%s)", stats.NetworkStatsInIECUnits.RateOut, stats.NetworkStatsInIECUnits.TotalOut)},
 		{"Bootstrap peers", fmt.Sprintf("%d/%d", stats.ConnectedBootstrapPeers, stats.TotalBootstrapPeers)},
-		{"DNS", formatWorkingStatus(stats.IsAwlDNSSetAsSystem)},
-		{"SOCKS5 Proxy", formatWorkingStatus(stats.SOCKS5.ListenerEnabled)},
-		{"SOCKS5 Proxy address", stats.SOCKS5.ListenAddress},
-		{"SOCKS5 Proxy exit node", stats.SOCKS5.UsingPeerName},
+		{"VPN", formatVPNStatus(stats.VPN)},
 		{"VPN gateway client", formatVPNGatewayClient(stats.VPNGateway)},
 	}
 	gw := stats.VPNGateway
 	if gw.ClientEnabled {
-		if gw.GatewayPublicIP != "" {
-			rows = append(rows, []string{"VPN gateway public IP", gw.GatewayPublicIP})
+		if detail := formatExitDetail(gw.GatewayPublicIP, gw.GatewayPing, gw.Connected, gw.GatewayThroughRelay); detail != "" {
+			rows = append(rows, []string{"VPN gateway exit", detail})
 		}
-		if gw.GatewayPing > 0 {
-			rows = append(rows, []string{"VPN gateway ping", gw.GatewayPing.Round(time.Millisecond).String()})
-		}
-		rows = append(rows, []string{"VPN gateway via relay", fmt.Sprintf("%v", gw.GatewayThroughRelay)})
 	}
 	rows = append(rows,
 		[]string{"VPN gateway server", formatWorkingStatus(stats.VPNGateway.ServerEnabled)},
+		[]string{"SOCKS5 Proxy", formatServiceStatus(stats.SOCKS5.ListenerEnabled, stats.SOCKS5.ListenAddress)},
+	)
+
+	s5 := stats.SOCKS5
+	if exit := formatSOCKS5ExitNode(s5); exit != "off" {
+		rows = append(rows, []string{"SOCKS5 exit node", exit})
+		if detail := formatExitDetail(s5.UsingPeerPublicIP, s5.UsingPeerPing, s5.Connected, s5.UsingPeerThroughRelay); detail != "" {
+			rows = append(rows, []string{"SOCKS5 exit", detail})
+		}
+	}
+
+	rows = append(rows,
+		[]string{"DNS", formatServiceStatus(stats.IsAwlDNSSetAsSystem, stats.AwlDNSAddress)},
 		[]string{"Reachability", strings.ToLower(stats.Reachability)},
-		[]string{"Uptime", stats.Uptime.Round(time.Second).String()},
+		[]string{"Uptime", formatUptime(stats.Uptime)},
 		[]string{"Server version", stats.ServerVersion},
 	)
 
 	table := tablewriter.NewWriter(w)
+	table.SetAutoWrapText(false)
 	table.AppendBulk(rows)
 
 	table.Render()
@@ -54,30 +62,138 @@ func printStatus(api *apiclient.Client, w io.Writer) error {
 	return nil
 }
 
+const (
+	statusWorking    = "working"
+	statusNotWorking = "not working"
+)
+
 func formatWorkingStatus(working bool) string {
 	if working {
-		return "working"
+		return statusWorking
 	}
-	return "not working"
+	return statusNotWorking
 }
 
-// formatVPNGatewayClient renders the client-side VPN gateway state in a
-// single line: either "off", or the gateway peer's name + connectivity.
-// Mirrors how SOCKS5 status splits across two rows but compresses to one
-// since VPN gateway has fewer knobs to surface.
+// formatEnabled renders an on/off feature toggle.
+func formatEnabled(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}
+
+// formatConnected renders libp2p connectivity to a peer.
+func formatConnected(connected bool) string {
+	if connected {
+		return "connected"
+	}
+	return "disconnected"
+}
+
+// formatServiceStatus renders an enabled/disabled service and, when enabled,
+// appends its listen address in parentheses, e.g. "working (127.0.0.66:53)".
+// The address is omitted while the service is off.
+func formatServiceStatus(enabled bool, addr string) string {
+	if !enabled {
+		return statusNotWorking
+	}
+	if addr != "" {
+		return fmt.Sprintf("%s (%s)", statusWorking, addr)
+	}
+	return statusWorking
+}
+
+// formatVPNStatus renders the local VPN interface state, including the
+// interface name and assigned address when it is up, e.g.
+// "working (awl0, 10.66.0.1/24)".
+func formatVPNStatus(vpn entity.VPNInfo) string {
+	if !vpn.VPNInterfaceEnabled {
+		return statusNotWorking
+	}
+	var parts []string
+	if vpn.InterfaceName != "" {
+		parts = append(parts, vpn.InterfaceName)
+	}
+	if vpn.IPNet != "" {
+		parts = append(parts, vpn.IPNet)
+	}
+	if len(parts) == 0 {
+		return statusWorking
+	}
+	return fmt.Sprintf("%s (%s)", statusWorking, strings.Join(parts, ", "))
+}
+
+// formatExitDetail renders a compact one-line summary of a selected exit peer
+// (SOCKS5 or VPN gateway): "<public IP>, ping <N>ms, direct/via relay". Each
+// part is included only when meaningful; the relay part appears only while
+// connected. Returns "" when nothing is known.
+func formatExitDetail(publicIP string, ping time.Duration, connected, throughRelay bool) string {
+	var parts []string
+	if publicIP != "" {
+		parts = append(parts, publicIP)
+	}
+	if ping > 0 {
+		parts = append(parts, "ping "+ping.Round(time.Millisecond).String())
+	}
+	if connected {
+		parts = append(parts, formatRelay(throughRelay))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatRelay renders the connection path of an exit peer in human terms.
+func formatRelay(throughRelay bool) string {
+	if throughRelay {
+		return "via relay"
+	}
+	return "direct"
+}
+
+// formatUptime renders uptime with spaces between units. For 24h or more it
+// switches to day granularity and drops seconds (e.g. "1d 21h 13m"); below 24h
+// it keeps seconds and omits leading zero units (e.g. "1h 25m 5s", "5s").
+func formatUptime(d time.Duration) string {
+	d = d.Round(time.Second)
+	days := d / (24 * time.Hour)
+	d -= days * 24 * time.Hour
+	hours := d / time.Hour
+	d -= hours * time.Hour
+	mins := d / time.Minute
+	d -= mins * time.Minute
+	secs := d / time.Second
+
+	if days > 0 {
+		return fmt.Sprintf("%dd %dh %dm", int64(days), int64(hours), int64(mins))
+	}
+
+	var parts []string
+	if hours > 0 {
+		parts = append(parts, fmt.Sprintf("%dh", int64(hours)))
+	}
+	if mins > 0 || hours > 0 {
+		parts = append(parts, fmt.Sprintf("%dm", int64(mins)))
+	}
+	parts = append(parts, fmt.Sprintf("%ds", int64(secs)))
+	return strings.Join(parts, " ")
+}
+
+func formatSOCKS5ExitNode(s5 entity.SOCKS5Info) string {
+	return formatExitClient(s5.UsingPeerID != "", s5.Connected, s5.UsingPeerName, s5.UsingPeerID)
+}
+
 func formatVPNGatewayClient(gw entity.VPNGatewayInfo) string {
-	if !gw.ClientEnabled {
+	return formatExitClient(gw.ClientEnabled, gw.Connected, gw.GatewayPeerName, gw.GatewayPeerID)
+}
+
+func formatExitClient(enabled, connected bool, peerName, peerID string) string {
+	if !enabled {
 		return "off"
 	}
-	name := gw.GatewayPeerName
+	name := peerName
 	if name == "" {
-		name = gw.GatewayPeerID
+		name = peerID
 	}
-	conn := "disconnected"
-	if gw.Connected {
-		conn = "connected"
-	}
-	return fmt.Sprintf("via %s [%s]", name, conn)
+	return fmt.Sprintf("%s [%s]", name, formatConnected(connected))
 }
 
 func printPeerId(api *apiclient.Client, w io.Writer) error {

--- a/cli/me_test.go
+++ b/cli/me_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/anywherelan/awl/entity"
+)
+
+func TestFormatUptime(t *testing.T) {
+	cases := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"seconds only", 5 * time.Second, "5s"},
+		{"minutes and seconds", 25*time.Minute + 5*time.Second, "25m 5s"},
+		{"hours minutes seconds", time.Hour + 25*time.Minute + 5*time.Second, "1h 25m 5s"},
+		{"zero minutes kept under a day", time.Hour + 5*time.Second, "1h 0m 5s"},
+		{"just under a day keeps seconds", 23*time.Hour + 59*time.Minute + 59*time.Second, "23h 59m 59s"},
+		{"exactly a day drops seconds", 24 * time.Hour, "1d 0h 0m"},
+		{"over a day drops seconds", 45*time.Hour + 13*time.Minute + 31*time.Second, "1d 21h 13m"},
+		{"sub-second rounds down", 900 * time.Millisecond, "1s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, formatUptime(tc.d))
+		})
+	}
+}
+
+func TestFormatExitDetail(t *testing.T) {
+	cases := []struct {
+		name         string
+		publicIP     string
+		ping         time.Duration
+		connected    bool
+		throughRelay bool
+		want         string
+	}{
+		{"full direct", "1.2.3.4", 674 * time.Millisecond, true, false, "1.2.3.4, ping 674ms, direct"},
+		{"full via relay", "1.2.3.4", 405 * time.Millisecond, true, true, "1.2.3.4, ping 405ms, via relay"},
+		{"no public ip", "", 100 * time.Millisecond, true, false, "ping 100ms, direct"},
+		{"zero ping dropped", "1.2.3.4", 0, true, false, "1.2.3.4, direct"},
+		{"disconnected drops relay", "1.2.3.4", 100 * time.Millisecond, false, false, "1.2.3.4, ping 100ms"},
+		{"nothing known", "", 0, false, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, formatExitDetail(tc.publicIP, tc.ping, tc.connected, tc.throughRelay))
+		})
+	}
+}
+
+func TestFormatVPNStatus(t *testing.T) {
+	require.Equal(t, "not working", formatVPNStatus(entity.VPNInfo{}))
+	require.Equal(t, "working (awl0, 10.66.0.1/24)", formatVPNStatus(entity.VPNInfo{
+		VPNInterfaceEnabled: true, InterfaceName: "awl0", IPNet: "10.66.0.1/24",
+	}))
+	require.Equal(t, "working (awl0)", formatVPNStatus(entity.VPNInfo{
+		VPNInterfaceEnabled: true, InterfaceName: "awl0",
+	}))
+	require.Equal(t, "working", formatVPNStatus(entity.VPNInfo{VPNInterfaceEnabled: true}))
+}
+
+func TestFormatServiceStatus(t *testing.T) {
+	require.Equal(t, "not working", formatServiceStatus(false, "127.0.0.66:53"))
+	require.Equal(t, "working (127.0.0.66:53)", formatServiceStatus(true, "127.0.0.66:53"))
+	require.Equal(t, "working", formatServiceStatus(true, ""))
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -40,9 +40,8 @@ func TestCLI_Me(t *testing.T) {
 		require.NoError(t, err)
 		// Row labels are static; values are dynamic (uptime, bootstrap peers, reachability)
 		for _, label := range []string{
-			"Download rate", "Upload rate", "Bootstrap peers",
-			"DNS", "SOCKS5 Proxy", "SOCKS5 Proxy address",
-			"SOCKS5 Proxy exit node",
+			"Name", "Download rate", "Upload rate", "Bootstrap peers",
+			"VPN", "DNS", "SOCKS5 Proxy",
 			"VPN gateway client", "VPN gateway server",
 			"Reachability", "Uptime", "Server version",
 		} {
@@ -388,11 +387,11 @@ func TestCLI_Gateway(t *testing.T) {
 	t.Run("StatusEnabled", func(t *testing.T) {
 		out, err := runCLI(ts, client, "gateway", "status")
 		require.NoError(t, err)
-		require.Contains(t, out, "VPN gateway client enabled: true")
+		require.Regexp(t, `Client:\s+enabled`, out)
+		require.Regexp(t, `Server:\s+disabled`, out)
 		require.Contains(t, out, "Gateway peer:")
 		require.Contains(t, out, exitNode.PeerID())
-		require.Contains(t, out, "Gateway via relay:")
-		require.Contains(t, out, "VPN gateway server enabled: false")
+		require.Regexp(t, `Connection:\s+(direct|via relay)`, out)
 	})
 
 	t.Run("List", func(t *testing.T) {
@@ -428,9 +427,11 @@ func TestCLI_Gateway(t *testing.T) {
 		statusOut, err := runCLI(ts, client, "me", "status")
 		require.NoError(t, err)
 		require.Contains(t, statusOut, "VPN gateway client")
-		require.Contains(t, statusOut, "via ")
+		require.Contains(t, statusOut, "peer_2")
 		require.Contains(t, statusOut, "[connected]")
-		require.Contains(t, statusOut, "VPN gateway via relay")
+		// The gateway detail row shows the connection path once connected.
+		require.True(t, strings.Contains(statusOut, "direct") || strings.Contains(statusOut, "via relay"),
+			"gateway detail row should show connection path")
 	})
 
 	t.Run("ServerDisable", func(t *testing.T) {


### PR DESCRIPTION
Closes #251

me status: merge each service's status and address into one row (VPN, DNS, SOCKS5), collapse exit-peer details into a single "<ip>, ping <N>ms, direct/via relay" line, regroup rows, reformat uptime ("1d 21h 13m"), and disable table wrapping.

gateway status: humanize booleans (enabled/disabled, [connected], direct/via relay), show the full peer id, fall back to id when the name is unknown, server before client, aligned as plain key: value lines.