### PR TITLE
vpn: fix remote crash and CPU-exhaustion from malformed tunnel packets

### DIFF
--- a/application_test.go
+++ b/application_test.go
@@ -405,6 +405,16 @@ func TestSOCKS5ProxyFallbackToOldProtocol(t *testing.T) {
 	// Remove new protocol handler from peer2 to simulate old peer
 	peer2.app.P2p.Host().RemoveStreamHandler(protocol.Socks5NoAuthMethod)
 
+	// Wait until peer1's peerstore reflects the removal (identify-push). Otherwise
+	// NewStreamMulti optimistically negotiates the stale /socks5-noauth/ against a
+	// peer that no longer handles it, and the dial fails with EOF.
+	ts.Eventually(func() bool {
+		supported, err := peer1.app.P2p.Host().Peerstore().
+			SupportsProtocols(peer2.app.P2p.PeerID(), protocol.Socks5NoAuthMethod)
+		ts.NoError(err)
+		return len(supported) == 0
+	}, 15*time.Second, 100*time.Millisecond)
+
 	// Allow peer1 to use peer2 as exit node
 	peer1Config, err := peer2.api.KnownPeerConfig(peer1.PeerID())
 	ts.NoError(err)

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -95,11 +95,20 @@ func TestReadPacketHeader_RejectsBothFlags(t *testing.T) {
 
 func TestReadPacketHeader_RejectsHugeSize(t *testing.T) {
 	var header [8]byte
-	binary.BigEndian.PutUint64(header[:], tunnelMaxLength+1)
+	binary.BigEndian.PutUint64(header[:], uint64(vpn.MaxPacketBodySize)+1)
 
 	_, _, err := ReadPacketHeader(bytes.NewReader(header[:]))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exceeds max")
+}
+
+func TestReadPacketHeader_AcceptsMaxBodySize(t *testing.T) {
+	var header [8]byte
+	binary.BigEndian.PutUint64(header[:], uint64(vpn.MaxPacketBodySize))
+
+	size, _, err := ReadPacketHeader(bytes.NewReader(header[:]))
+	require.NoError(t, err)
+	require.Equal(t, uint64(vpn.MaxPacketBodySize), size)
 }
 
 func TestReadPacketHeader_TruncatedStream(t *testing.T) {

--- a/protocol/tunnel.go
+++ b/protocol/tunnel.go
@@ -25,11 +25,6 @@ const (
 	tunnelFlagGatewayForward uint64 = 1 << 63
 	tunnelFlagGatewayReturn  uint64 = 1 << 62
 	tunnelLengthMask         uint64 = ^(tunnelFlagGatewayForward | tunnelFlagGatewayReturn)
-	// tunnelMaxLength bounds the per-packet size we'll accept on read. The
-	// real cap is vpn.maxContentSize (MTU + overhead); this is a generous
-	// upper bound to reject obvious garbage early without crossing package
-	// dependencies.
-	tunnelMaxLength uint64 = 1 << 20
 )
 
 // ReadPacketHeader reads an 8-byte tunnel packet header from the stream and
@@ -53,8 +48,8 @@ func ReadPacketHeader(stream io.Reader) (size uint64, dir vpn.GatewayDir, err er
 		dir = vpn.GatewayDirReturn
 	}
 	size = v & tunnelLengthMask
-	if size > tunnelMaxLength {
-		return 0, 0, fmt.Errorf("invalid tunnel header: size %d exceeds max %d", size, tunnelMaxLength)
+	if size > uint64(vpn.MaxPacketBodySize) {
+		return 0, 0, fmt.Errorf("invalid tunnel header: size %d exceeds max %d", size, vpn.MaxPacketBodySize)
 	}
 	return size, dir, nil
 }

--- a/vpn/iface_darwin.go
+++ b/vpn/iface_darwin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"strings"
 
 	"golang.zx2c4.com/wireguard/tun"
 )
@@ -21,26 +22,33 @@ func newTUN(ifname string, mtu int, localIP net.IP, ipMask net.IPMask) (tun.Devi
 	if err != nil {
 		return nil, fmt.Errorf("create tun: %v", err)
 	}
+	// Close the freshly created device if any later setup step fails, otherwise
+	// the TUN interface leaks.
+	success := false
+	defer func() {
+		if !success {
+			_ = tunDevice.Close()
+		}
+	}()
 	// Interface name must be utun[0-9]*
 	realIfname, err := tunDevice.Name()
 	if err != nil {
 		return nil, fmt.Errorf("get interface name: %v", err)
 	}
 
-	err = exec.Command("ifconfig", realIfname, "inet", ipNet.String(), localIP.String()).Run()
-	if err != nil {
-		return nil, fmt.Errorf("unable to setup interface mask: %v", err)
+	if out, err := exec.Command("ifconfig", realIfname, "inet", ipNet.String(), localIP.String()).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("unable to setup interface mask: %v: %s", err, strings.TrimSpace(string(out)))
 	}
 
 	ipNetMasked := &net.IPNet{
 		IP:   localIP.Mask(ipMask),
 		Mask: ipMask,
 	}
-	err = exec.Command("route", "-q", "-n", "add", "-inet", ipNetMasked.String(), "-iface", realIfname).Run()
-	if err != nil {
-		return nil, fmt.Errorf("unable to setup interface route: %v", err)
+	if out, err := exec.Command("route", "-q", "-n", "add", "-inet", ipNetMasked.String(), "-iface", realIfname).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("unable to setup interface route: %v: %s", err, strings.TrimSpace(string(out)))
 	}
 
+	success = true
 	return tunDevice, nil
 }
 

--- a/vpn/iface_linux.go
+++ b/vpn/iface_linux.go
@@ -16,6 +16,14 @@ func newTUN(ifname string, mtu int, localIP net.IP, ipMask net.IPMask) (tun.Devi
 	if err != nil {
 		return nil, fmt.Errorf("create tun: %v", err)
 	}
+	// Close the freshly created device if any later setup step fails, otherwise
+	// the TUN interface leaks.
+	success := false
+	defer func() {
+		if !success {
+			_ = tunDevice.Close()
+		}
+	}()
 
 	link, err := netlink.LinkByName(ifname)
 	if err != nil {
@@ -36,6 +44,7 @@ func newTUN(ifname string, mtu int, localIP net.IP, ipMask net.IPMask) (tun.Devi
 		return nil, fmt.Errorf("unable to UP interface: %v", err)
 	}
 
+	success = true
 	return tunDevice, nil
 }
 

--- a/vpn/iface_windows.go
+++ b/vpn/iface_windows.go
@@ -44,6 +44,14 @@ func newTUN(ifname string, mtu int, localIP net.IP, ipMask net.IPMask) (tun.Devi
 	if err != nil {
 		return nil, fmt.Errorf("do as system: %v", err)
 	}
+	// Close the freshly created adapter if any later setup step fails, otherwise
+	// the Wintun adapter leaks.
+	success := false
+	defer func() {
+		if !success {
+			_ = tunDevice.Close()
+		}
+	}()
 
 	nativeTunDevice := tunDevice.(*tun.NativeTun)
 	luid := winipcfg.LUID(nativeTunDevice.LUID())
@@ -54,7 +62,6 @@ func newTUN(ifname string, mtu int, localIP net.IP, ipMask net.IPMask) (tun.Devi
 	// force NLMTU ourselves via winipcfg, otherwise local apps see MTU=65535,
 	// send oversized packets, and the size check in ReadTUNPackets silently drops them.
 	if err := setInterfaceMTU(logger, luid, winipcfg.AddressFamily(windows.AF_INET), uint32(mtu)); err != nil {
-		tunDevice.Close()
 		return nil, fmt.Errorf("set IPv4 MTU on tun: %v", err)
 	}
 	// TODO: support ipv6. Forwarding still ignores IPv6 packets (see Device.WritePacket),
@@ -74,6 +81,7 @@ func newTUN(ifname string, mtu int, localIP net.IP, ipMask net.IPMask) (tun.Devi
 		return nil, fmt.Errorf("unable to setup interface IP: %v", err)
 	}
 
+	success = true
 	return tunDevice, nil
 }
 

--- a/vpn/packet.go
+++ b/vpn/packet.go
@@ -2,6 +2,7 @@ package vpn
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"net"
 
@@ -61,12 +62,17 @@ func (data *Packet) clear() {
 
 func (data *Packet) CopyTo(copyPacket *Packet) {
 	*copyPacket = *data
-	// set Packet reference to a new buffer
+	// Buffer is an array copied by value above, but Packet/Src/Dst are slice
+	// headers still aliasing data.Buffer. Re-derive them as sub-slices of the
+	// copy's own buffer.
 	copyPacket.Packet = copyPacket.Buffer[tunPacketOffset : len(data.Packet)+tunPacketOffset]
+	if data.Src != nil {
+		copyPacket.setAddrs()
+	}
 }
 
 func (data *Packet) ReadFrom(stream io.Reader) (int64, error) {
-	var totalRead = tunPacketOffset
+	totalRead := tunPacketOffset
 	for {
 		n, err := stream.Read(data.Buffer[totalRead:])
 		totalRead += n
@@ -75,6 +81,13 @@ func (data *Packet) ReadFrom(stream io.Reader) (int64, error) {
 			return int64(totalRead - tunPacketOffset), nil
 		} else if err != nil {
 			return int64(totalRead - tunPacketOffset), err
+		}
+		// The buffer is sized with slack above the MTU (maxContentSize), so a
+		// valid single-packet body never fills it. A full buffer means an
+		// oversized frame; reject it instead of reading into the empty tail
+		// (which would spin on (0, nil) reads).
+		if totalRead == len(data.Buffer) {
+			return int64(totalRead - tunPacketOffset), fmt.Errorf("packet body exceeds max size %d bytes", MaxPacketBodySize)
 		}
 	}
 }
@@ -90,19 +103,25 @@ func (data *Packet) Parse() bool {
 		if len(packet) < ipv4.HeaderLen {
 			return false
 		}
+		// Validate the header length against the actual packet so downstream
+		// slicing (RecalculateChecksum) can't run past the packet and panic.
+		// Transport-length is not enforced here (it would drop legit non-first IP
+		// fragments); RecalculateChecksum guards its own transport slicing.
+		ipHeaderLen := int(packet[0]&0x0f) << 2
+		if ipHeaderLen < ipv4.HeaderLen || ipHeaderLen > len(packet) {
+			return false
+		}
+		data.IPProtocol = packet[9]
 
-		data.Src = packet[device.IPv4offsetSrc : device.IPv4offsetSrc+net.IPv4len]
-		data.Dst = packet[device.IPv4offsetDst : device.IPv4offsetDst+net.IPv4len]
 		data.IsIPv6 = false
-		data.IPProtocol = data.Packet[9]
+		data.setAddrs()
 	case ipv6.Version:
 		if len(packet) < ipv6.HeaderLen {
 			return false
 		}
 
-		data.Src = packet[device.IPv6offsetSrc : device.IPv6offsetSrc+net.IPv6len]
-		data.Dst = packet[device.IPv6offsetDst : device.IPv6offsetDst+net.IPv6len]
 		data.IsIPv6 = true
+		data.setAddrs()
 		// TODO: set data.IPProtocol
 	default:
 		return false
@@ -114,24 +133,45 @@ func (data *Packet) Parse() bool {
 func (data *Packet) RecalculateChecksum() {
 	if data.IsIPv6 {
 		// TODO
-	} else {
-		ipHeaderLen := int(data.Packet[0]&0x0f) << 2
-		copy(data.Packet[ipv4offsetChecksum:], []byte{0, 0})
-		ipChecksum := checksumIPv4Header(data.Packet[:ipHeaderLen])
-		binary.BigEndian.PutUint16(data.Packet[ipv4offsetChecksum:], ipChecksum)
+		return
+	}
+	// Guard against malformed lengths so a bad packet can't slice past bounds and
+	// panic, even if RecalculateChecksum is called without a prior valid Parse.
+	ipHeaderLen := int(data.Packet[0]&0x0f) << 2
+	if ipHeaderLen < ipv4.HeaderLen || ipHeaderLen > len(data.Packet) {
+		return
+	}
+	copy(data.Packet[ipv4offsetChecksum:], []byte{0, 0})
+	ipChecksum := checksumIPv4Header(data.Packet[:ipHeaderLen])
+	binary.BigEndian.PutUint16(data.Packet[ipv4offsetChecksum:], ipChecksum)
 
-		switch protocol := data.Packet[9]; protocol {
-		case IPProtocolTCP:
-			tcpOffsetChecksum := ipHeaderLen + 16
-			copy(data.Packet[tcpOffsetChecksum:], []byte{0, 0})
-			checksum := checksumIPv4TCPUDP(data.Packet[ipHeaderLen:], uint32(protocol), data.Src, data.Dst)
-			binary.BigEndian.PutUint16(data.Packet[tcpOffsetChecksum:], checksum)
-		case IPProtocolUDP:
-			udpOffsetChecksum := ipHeaderLen + 6
-			copy(data.Packet[udpOffsetChecksum:], []byte{0, 0})
-			checksum := checksumIPv4TCPUDP(data.Packet[ipHeaderLen:], uint32(protocol), data.Src, data.Dst)
-			binary.BigEndian.PutUint16(data.Packet[udpOffsetChecksum:], checksum)
+	switch protocol := data.Packet[9]; protocol {
+	case IPProtocolTCP:
+		if len(data.Packet) < ipHeaderLen+18 {
+			return
 		}
+		tcpOffsetChecksum := ipHeaderLen + 16
+		copy(data.Packet[tcpOffsetChecksum:], []byte{0, 0})
+		checksum := checksumIPv4TCPUDP(data.Packet[ipHeaderLen:], uint32(protocol), data.Src, data.Dst)
+		binary.BigEndian.PutUint16(data.Packet[tcpOffsetChecksum:], checksum)
+	case IPProtocolUDP:
+		if len(data.Packet) < ipHeaderLen+8 {
+			return
+		}
+		udpOffsetChecksum := ipHeaderLen + 6
+		copy(data.Packet[udpOffsetChecksum:], []byte{0, 0})
+		checksum := checksumIPv4TCPUDP(data.Packet[ipHeaderLen:], uint32(protocol), data.Src, data.Dst)
+		binary.BigEndian.PutUint16(data.Packet[udpOffsetChecksum:], checksum)
+	}
+}
+
+func (data *Packet) setAddrs() {
+	if data.IsIPv6 {
+		data.Src = data.Packet[device.IPv6offsetSrc : device.IPv6offsetSrc+net.IPv6len]
+		data.Dst = data.Packet[device.IPv6offsetDst : device.IPv6offsetDst+net.IPv6len]
+	} else {
+		data.Src = data.Packet[device.IPv4offsetSrc : device.IPv4offsetSrc+net.IPv4len]
+		data.Dst = data.Packet[device.IPv4offsetDst : device.IPv4offsetDst+net.IPv4len]
 	}
 }
 

--- a/vpn/packet_test.go
+++ b/vpn/packet_test.go
@@ -3,10 +3,12 @@ package vpn
 import (
 	"bytes"
 	"encoding/hex"
+	"io"
 	"net"
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -44,6 +46,131 @@ func BenchmarkPacket_PoolCopyToClear(b *testing.B) {
 		copyPacket.clear()
 		packetsPool.Put(copyPacket)
 	}
+}
+
+// a peer-controlled IPv4 packet must never be able to crash the process
+// through Parse/RecalculateChecksum slicing past the packet bounds.
+func TestPacket_Parse_RejectsMalformedIPv4(t *testing.T) {
+	newRawIPv4 := func(size int, ihlWords byte, protocol byte) []byte {
+		raw := make([]byte, size)
+		raw[0] = 0x40 | (ihlWords & 0x0f) // version 4 + IHL
+		if len(raw) > 9 {
+			raw[9] = protocol
+		}
+		return raw
+	}
+
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{"ihl larger than packet", newRawIPv4(20, 15, 0)}, // ipHeaderLen is 60 > 20
+		{"ihl below minimum", newRawIPv4(20, 4, 0)},       // ipHeaderLen is 16 < 20
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := new(Packet)
+			_, _ = p.ReadFrom(bytes.NewReader(tc.raw))
+			require.False(t, p.Parse(), "malformed packet must be rejected by Parse")
+		})
+	}
+}
+
+// defense in depth: RecalculateChecksum must be panic-safe on malformed or
+// truncated packets, including when called without a prior successful Parse.
+func TestPacket_RecalculateChecksum_MalformedNoPanic(t *testing.T) {
+	build := func(size int, ihlWords, protocol byte) *Packet {
+		raw := make([]byte, size)
+		raw[0] = 0x40 | (ihlWords & 0x0f)
+		if len(raw) > 9 {
+			raw[9] = protocol
+		}
+		p := new(Packet)
+		_, _ = p.ReadFrom(bytes.NewReader(raw))
+		// Src/Dst are populated by Parse; the guards must hold even when they are
+		// nil (RecalculateChecksum called directly).
+		return p
+	}
+
+	cases := []struct {
+		name            string
+		size            int
+		ihlWords, proto byte
+	}{
+		{"ihl past packet, tcp", 20, 15, IPProtocolTCP},
+		{"ihl past packet, udp", 20, 15, IPProtocolUDP},
+		{"valid ihl, tcp header truncated", 20, 5, IPProtocolTCP},
+		{"valid ihl, udp header truncated", 24, 5, IPProtocolUDP},
+		{"valid ihl, non-transport proto", 20, 5, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := build(tc.size, tc.ihlWords, tc.proto)
+			require.NotPanics(t, func() { p.RecalculateChecksum() })
+		})
+	}
+}
+
+// C2: an oversized tunnel packet must return an error rather than spinning
+// forever on zero-length reads into the full buffer. Reproduces the production
+// path (io.LimitedReader wrapping the peer stream).
+func TestPacket_ReadFrom_RejectsOversized(t *testing.T) {
+	body := bytes.Repeat([]byte{0xab}, MaxPacketBodySize*2)
+	lr := &io.LimitedReader{R: bytes.NewReader(body), N: int64(len(body))}
+	p := new(Packet)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := p.ReadFrom(lr)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeds max")
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadFrom looped forever on oversized packet")
+	}
+}
+
+// C2 boundary: the largest body that still leaves the buffer with room (i.e.
+// does not fill it) must be read successfully.
+func TestPacket_ReadFrom_AcceptsMaxSize(t *testing.T) {
+	size := MaxPacketBodySize - 1
+	body := bytes.Repeat([]byte{0xab}, size)
+	lr := &io.LimitedReader{R: bytes.NewReader(body), N: int64(len(body))}
+	p := new(Packet)
+
+	n, err := p.ReadFrom(lr)
+	require.NoError(t, err)
+	require.Equal(t, int64(size), n)
+	require.Len(t, p.Packet, size)
+}
+
+// H11: CopyTo must re-point Src/Dst onto the copy's own buffer, otherwise they
+// dangle into the original's buffer and read garbage once it is reused.
+func TestPacket_CopyTo_SrcDstAliasCopyBuffer(t *testing.T) {
+	a := require.New(t)
+	orig, _ := testUDPPacket()
+	a.NotNil(orig.Src)
+	a.NotNil(orig.Dst)
+
+	wantSrc := append(net.IP(nil), orig.Src...)
+	wantDst := append(net.IP(nil), orig.Dst...)
+
+	cp := new(Packet)
+	orig.CopyTo(cp)
+
+	// Simulate the original returning to the pool and its buffer being reused.
+	for i := range orig.Buffer {
+		orig.Buffer[i] = 0xff
+	}
+
+	a.Equal(wantSrc, cp.Src, "copy Src must survive original buffer reuse")
+	a.Equal(wantDst, cp.Dst, "copy Dst must survive original buffer reuse")
+	// Recalculating on the copy must still yield the correct checksum.
+	a.NotPanics(func() { cp.RecalculateChecksum() })
 }
 
 func testUDPPacket() (*Packet, []byte) {

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -20,6 +20,11 @@ const (
 	maxContentSize = InterfaceMTU + 100
 	// internal tun header. see offset in tun_darwin (4) and tun_linux (virtioNetHdrLen, currently 10)
 	tunPacketOffset = 14
+	// MaxPacketBodySize is the largest tunnel packet body (an IP packet, without
+	// the internal TUN header offset) that Packet.Buffer can hold. Peers must not
+	// send larger frames: protocol.ReadPacketHeader rejects oversized ones up front and
+	// Packet.ReadFrom refuses to overflow the buffer.
+	MaxPacketBodySize = maxContentSize - tunPacketOffset
 )
 
 type Device struct {


### PR DESCRIPTION
Parse now validates IPv4 IHL against the packet length, and RecalculateChecksum guards its header/transport slicing, so a peer can no longer crash the process with a short packet claiming a large IHL or TCP/UDP protocol.

ReadFrom refuses to overflow Packet.Buffer instead of spinning forever on zero-length reads, and ReadPacketHeader rejects sizes above the real buffer capacity (new vpn.MaxPacketBodySize) rather than the 1 MiB protocol bound that was ~300x too large.