### PR TITLE
awldns: resolve .awl names on Android via a netstack DNS interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 - [Terminal-based client](#terminal-based-client)
   - [Common examples](#common-examples)
 - [Upgrading](#upgrading)
+- [Platform notes & known limitations](#platform-notes--known-limitations)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -195,8 +196,6 @@ For testing, there is a public peer that auto-accepts invitations, so you don't 
 Open the web UI at http://admin.awl (or the Android app). On the Status / Overview page, click the QR icon next to your device name to show your own `peer_id`. To invite someone, click *Add peer* (on Android, the **+** floating button on the Peers tab).
 
 To try the public tester: enter `12D3KooWJMUjt9b5T1umzgzjLv5yG2ViuuF4qjmN65tsRXZGS1p8` as peer id, name it `awl-tester`, save. After a few seconds it will appear in your peer list. Open http://awl-tester.awl/ — you should see a network speed-test page.
-
-> `.awl` DNS is not yet available on Android ([#17](https://github.com/anywherelan/awl/issues/17)); on Android you access peers by IP.
 
 When someone invites you, a notification will appear; accept or block in the admin UI.
 
@@ -495,6 +494,24 @@ systemctl restart awl
 ```
 
 As an alternative on desktop or server: download the new build from the [releases page](https://github.com/anywherelan/awl/releases) and replace the files manually.
+
+## Platform notes & known limitations
+
+### `.awl` name resolution
+
+`.awl` names resolve on every platform, but the mechanism differs:
+
+- **Desktop (Linux / Windows / macOS):** awl runs a local resolver and registers it with the OS. Where the OS supports split-DNS only the `.awl` zone is captured; the rest of your DNS is left untouched, so LAN names keep working.
+- **Android:** the app resolves `.awl` inside the tunnel — `.awl` is answered locally, everything else is forwarded to the configured upstream resolver (`1.1.1.1` by default, `dns.upstreamDNSAddress` in the config). This has a few consequences:
+  - **Private DNS in strict mode** (a hostname set under Android's *Private DNS* setting) bypasses the VPN's DNS entirely, so `.awl` names won't resolve. The default *Automatic* mode works fine.
+  - While DNS is enabled, all queries go to the configured upstream instead of your network's own resolver, so LAN-only names handed out by your router (e.g. `printer.lan`) won't resolve.
+  - `admin.awl` is not reachable on Android — use the app's own UI instead.
+  - `dns.disableDNS: true` in the config turns awl's DNS handling off entirely: `.awl` stops resolving and queries go straight to the system resolver again.
+
+### Other limitations
+
+- **IPv6 inside the tunnel is not supported** — IPv6 packets are dropped, only IPv4 is carried.
+- **Serving as a VPN gateway / exit node** is not available on every platform — see the [support table](#vpn-gateway-full-tunnel-exit-node).
 
 # Contributing
 

--- a/application.go
+++ b/application.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/anywherelan/awl/api"
 	"github.com/anywherelan/awl/awldns"
+	"github.com/anywherelan/awl/awldns/dnsbridge"
 	"github.com/anywherelan/awl/awlevent"
 	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/metrics"
@@ -194,12 +195,7 @@ func (a *Application) Init(ctx context.Context, tunDevice tun.Device) error {
 	go a.SOCKS5.ServeConns(a.ctx)
 
 	if !a.Conf.DNS.DisableDNS && !a.Conf.VPNConfig.DisableVPNInterface {
-		interfaceName, err := a.vpnDevice.InterfaceName()
-		if err != nil {
-			a.logger.Errorf("failed to get TUN interface name: %v", err)
-		} else {
-			a.Dns.initDNS(interfaceName)
-		}
+		a.setupDNS()
 	}
 
 	// Metrics
@@ -216,6 +212,23 @@ func (a *Application) Init(ctx context.Context, tunDevice tun.Device) error {
 	a.logger.Info("Application initialized successfully")
 
 	return nil
+}
+
+// setupDNS picks the platform DNS path. On Android there are no OS sockets
+// and no OS DNS configurator: DNS packets are intercepted from the TUN read
+// path into a netstack bridge instead.
+func (a *Application) setupDNS() {
+	if runtime.GOOS == "android" {
+		a.Dns.initDNSAndroid(a.vpnDevice, a.Tunnel)
+		return
+	}
+
+	interfaceName, err := a.vpnDevice.InterfaceName()
+	if err != nil {
+		a.logger.Errorf("failed to get TUN interface name: %v", err)
+		return
+	}
+	a.Dns.initDNS(interfaceName)
 }
 
 func (a *Application) SetupLoggerAndConfig(appType config.AppType) *log.ZapEventLogger {
@@ -373,15 +386,17 @@ type DNSService struct {
 
 	mu                  sync.Mutex
 	dnsHost             string
-	dnsFQDN             dnsname.FQDN
 	dnsOsConfigurator   dns.OSConfigurator
 	dnsResolver         *awldns.Resolver
+	dnsBridge           *dnsbridge.Bridge
 	upstreamDNS         string
 	isAwlDNSSetAsSystem bool
 	// forceUpstream forces the awl resolver to capture all queries
 	// (MatchDomains=nil) and forward them to the configured public upstream so
 	// DNS traverses the tunnel instead of leaking to the system resolver. Set
-	// in VPN gateway client mode.
+	// in VPN gateway client mode. Desktop only: the Android netstack bridge has
+	// no split-DNS choice to make (it already captures all device DNS), so it
+	// leaves this at zero and ForceUpstreamDNS is a no-op there.
 	forceUpstream bool
 }
 
@@ -401,20 +416,6 @@ func (a *DNSService) initDNS(interfaceName string) {
 	}
 	a.dnsHost = dnsHost
 
-	fqdn, err := dnsname.ToFQDN(awldns.LocalDomain)
-	if err != nil {
-		panic(err)
-	}
-	a.dnsFQDN = fqdn
-
-	// TODO(android awldns): on Android this NewResolver cannot bind :53 (needs
-	// root) and dnsOsConfigurator.SetDNS below fails (no writable resolv.conf),
-	// so awldns is effectively inert there and .awl names do not resolve. The
-	// Android host instead points VpnService at DNS.UpstreamDNSAddress directly
-	// (see awl-flutter MainActivity.establishTun), which prevents leaks but
-	// gives no .awl resolution. A full fix would intercept :53 to a magic awl
-	// IP inside the tunnel read-path (userspace netstack),
-	// rather than binding an OS socket.
 	a.dnsResolver = awldns.NewResolver(dnsAddr)
 	a.upstreamDNS = a.conf.DNS.UpstreamDNSAddress
 	a.forceUpstream = a.conf.VPNGateway.ClientEnabled
@@ -436,6 +437,60 @@ func (a *DNSService) initDNS(interfaceName string) {
 	}
 
 	a.applyOSDNSConfigLocked()
+}
+
+// initDNSAndroid sets up the Android DNS path: no OS sockets and no OS DNS
+// configurator. A netstack bridge (awldns/dnsbridge) owns the in-subnet DNS
+// IP, the Tunnel feeds it packets intercepted from the TUN read path, and the
+// resolver serves on the bridge's listeners. The Android host passes the same
+// IP to VpnService.Builder.addDnsServer, so all device DNS arrives there. On
+// any failure DNS stays off with a log; VPN keeps working.
+func (a *DNSService) initDNSAndroid(vpnDevice *vpn.Device, tunnel *service.Tunnel) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	dnsIP := a.conf.NetstackDNSIP()
+	if dnsIP == nil {
+		a.logger.Errorf("no free IP for the DNS server in VPN subnet %s, DNS is disabled", a.conf.VPNConfig.IPNet)
+		return
+	}
+	dnsAddr, ok := netip.AddrFromSlice(dnsIP.To4())
+	if !ok {
+		a.logger.Errorf("invalid DNS server IP %v, DNS is disabled", dnsIP)
+		return
+	}
+
+	bridge, err := dnsbridge.New(dnsAddr, vpn.InterfaceMTU, vpnDevice.WriteRawPacket)
+	if err != nil {
+		a.logger.Errorf("create DNS netstack bridge, DNS is disabled: %v", err)
+		return
+	}
+	a.dnsBridge = bridge
+	a.dnsResolver = awldns.NewResolverFromListeners(bridge.UDPConn(), bridge.TCPListener(),
+		net.JoinHostPort(dnsIP.String(), awldns.DefaultDNSPort))
+
+	// TODO(android awldns): use the system DNS servers reported by the Android
+	// layer (ConnectivityManager network callback) as upstream, so LAN names
+	// keep resolving; for now non-.awl queries always go to the configured
+	// public upstream. In VPN gateway client mode the resolver's upstream
+	// socket is deliberately unprotected: its traffic loops back into the TUN
+	// and leaves through the gateway peer — no DNS leak.
+	a.upstreamDNS = a.conf.DNS.UpstreamDNSAddress
+	a.refreshDNSConfigLocked()
+
+	awlevent.WrapSubscriptionToCallback(a.ctx, func(_ interface{}) {
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		a.refreshDNSConfigLocked()
+	}, a.eventbus, new(awlevent.KnownPeerChanged))
+
+	tunnel.SetDNSHandler(dnsIP, bridge)
+	// The interceptor now handles all device DNS — the host sets the same IP
+	// via addDnsServer — which is exactly what this flag means to the UI.
+	// (dnsIP is config.NetstackDNSIP, reserved from peers since setDefaults.)
+	a.isAwlDNSSetAsSystem = true
+
+	a.logger.Infof("DNS interceptor is set up on %s (upstream %s)", dnsAddr, a.upstreamDNS)
 }
 
 // applyOSDNSConfigLocked (re)computes the OS DNS takeover config from the
@@ -544,7 +599,12 @@ func (a *DNSService) refreshDNSConfigLocked() {
 		return
 	}
 	dnsNamesMapping := a.conf.DNSNamesMapping()
-	dnsNamesMapping[config.AdminHttpServerDomainName] = config.AdminHttpServerIP
+	// TODO(android awldns): make admin.awl work on Android. The admin server is
+	// not reachable on AdminHttpServerIP there (the API listens elsewhere and
+	// port 80 cannot be bound), so don't advertise a dead name.
+	if runtime.GOOS != "android" {
+		dnsNamesMapping[config.AdminHttpServerDomainName] = config.AdminHttpServerIP
+	}
 	a.dnsResolver.ReceiveConfiguration(a.upstreamDNS, dnsNamesMapping)
 }
 
@@ -560,8 +620,14 @@ func (a *DNSService) Close() {
 	if a.dnsResolver != nil {
 		a.dnsResolver.Close()
 	}
+	if a.dnsBridge != nil {
+		a.dnsBridge.Close()
+	}
 }
 
+// AwlDNSAddress returns the resolver address (ip:port) to display in the
+// status API/UI/CLI, empty until both resolver servers are up. Not the
+// host-wiring IP — for that see NetstackDNSServerIP.
 func (a *DNSService) AwlDNSAddress() string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -575,6 +641,17 @@ func (a *DNSService) IsAwlDNSSetAsSystem() bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.isAwlDNSSetAsSystem
+}
+
+// NetstackDNSServerIP returns the in-tunnel IP owned by the running DNS
+// interceptor (Android), nil when the interceptor is not set up.
+func (a *DNSService) NetstackDNSServerIP() net.IP {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.dnsBridge == nil {
+		return nil
+	}
+	return a.dnsBridge.DNSIP().AsSlice()
 }
 
 // configMetricsAdapter implements metrics.ConfigMetrics by combining Config and AuthStatus.

--- a/application_gateway_test.go
+++ b/application_gateway_test.go
@@ -1145,3 +1145,32 @@ func TestGatewayUnknownPeerIDAtStartupFailsBoot(t *testing.T) {
 	ts.Equal(unknownPeerID, tp.app.Conf.VPNGateway.GatewayPeerID,
 		"unknown peer at startup must NOT auto-wipe GatewayPeerID")
 }
+
+// TestGatewayDNSInterception verifies the DNS interceptor filter runs before
+// the gateway-client branch in HandleReadPackets: a packet to the in-tunnel
+// DNS IP is diverted to the handler instead of being dropped as in-subnet
+// traffic (or forwarded to the exit node).
+func TestGatewayDNSInterception(t *testing.T) {
+	skipIfVPNGatewayUnsupported(t)
+	ts := NewTestSuite(t)
+
+	client, _, _ := setupGatewayPeers(ts)
+
+	dnsIP := client.app.Conf.NetstackDNSIP()
+	ts.NotNil(dnsIP)
+
+	intercepted := make(chan []byte, 16)
+	client.app.Tunnel.SetDNSHandler(dnsIP, dnsHandlerFunc(func(packet []byte) {
+		intercepted <- append([]byte{}, packet...)
+	}))
+
+	dnsPacket := testPacketWithDest(0, dnsIP.String())
+	client.tun.Outbound <- [][]byte{dnsPacket}
+
+	select {
+	case got := <-intercepted:
+		ts.Equal(dnsPacket, got)
+	case <-time.After(5 * time.Second):
+		ts.FailNow("dns packet was not intercepted in gateway client mode")
+	}
+}

--- a/application_test.go
+++ b/application_test.go
@@ -2,6 +2,7 @@ package awl
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
@@ -15,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/miekg/dns"
 	"github.com/quic-go/quic-go/integrationtests/tools/israce"
 	"golang.org/x/net/proxy"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/entity"
 	"github.com/anywherelan/awl/protocol"
+	"github.com/anywherelan/awl/vpn"
 )
 
 func TestMakeFriends(t *testing.T) {
@@ -1081,5 +1084,120 @@ func TestChooseDNSPolicy(t *testing.T) {
 				t.Errorf("upstream = %q, want %q", upstream, tt.wantUpstream)
 			}
 		})
+	}
+}
+
+// dnsHandlerFunc adapts a function to service.DNSPacketHandler.
+type dnsHandlerFunc func(packet []byte)
+
+func (f dnsHandlerFunc) HandlePacket(packet []byte) { f(packet) }
+
+// TestDNSHandlerTunnelFilter checks the Tunnel-side interceptor filter alone:
+// only packets addressed to the DNS IP reach the installed handler.
+func TestDNSHandlerTunnelFilter(t *testing.T) {
+	ts := NewTestSuite(t)
+	peer1 := ts.NewTestPeer(true)
+
+	dnsIP := peer1.app.Conf.NetstackDNSIP()
+	ts.NotNil(dnsIP)
+
+	intercepted := make(chan []byte, 16)
+	peer1.app.Tunnel.SetDNSHandler(dnsIP, dnsHandlerFunc(func(packet []byte) {
+		intercepted <- append([]byte{}, packet...)
+	}))
+
+	dnsPacket := testPacketWithDest(0, dnsIP.String())
+	// Must not reach the handler: unknown peer IP and broadcast.
+	otherPacket := testPacketWithDest(0, "10.66.0.50")
+	broadcastPacket := testPacketWithDest(0, "10.66.255.255")
+	peer1.tun.Outbound <- [][]byte{dnsPacket, otherPacket, broadcastPacket}
+
+	select {
+	case got := <-intercepted:
+		ts.Equal(dnsPacket, got)
+	case <-time.After(5 * time.Second):
+		ts.FailNow("dns packet was not intercepted")
+	}
+
+	select {
+	case got := <-intercepted:
+		_, dst := parsePacketIPs(got)
+		ts.FailNowf("unexpected packet reached dns handler", "dst %s", dst)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestDNSAndroidInterceptor runs the Android DNS path end-to-end over the
+// TestTUN: a raw UDP DNS query for a peer name goes into the TUN read path,
+// through the interceptor into the netstack bridge and the awldns resolver,
+// and the response packet comes back out of the TUN write path.
+func TestDNSAndroidInterceptor(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	peer1 := ts.NewTestPeer(true)
+	peer2 := ts.NewTestPeer(true)
+	ts.makeFriends(peer2, peer1)
+
+	// In production Application.Init wires this behind runtime.GOOS ==
+	// "android"; the test drives the same code path directly.
+	peer1.app.Dns.initDNSAndroid(peer1.app.vpnDevice, peer1.app.Tunnel)
+
+	dnsIP := peer1.app.Conf.NetstackDNSIP()
+	ts.NotNil(dnsIP)
+	dnsAddress := net.JoinHostPort(dnsIP.String(), awldns.DefaultDNSPort)
+	ts.Eventually(func() bool {
+		return peer1.app.Dns.AwlDNSAddress() == dnsAddress
+	}, 5*time.Second, 10*time.Millisecond)
+	ts.True(peer1.app.Dns.IsAwlDNSSetAsSystem())
+	// The running interceptor reports the same IP the config computes
+	// (what gomobile's DnsServerIP relies on in the reconfigure_vpn flow).
+	ts.Equal(dnsIP, peer1.app.Dns.NetstackDNSServerIP())
+
+	knownPeer, exists := peer1.app.Conf.GetPeer(peer2.PeerID())
+	ts.True(exists)
+	ts.NotEmpty(knownPeer.DomainName)
+
+	inbound := make(chan []byte, 100)
+	peer1.tun.SetInboundCapture(0, inbound)
+
+	query := new(dns.Msg)
+	query.SetQuestion(knownPeer.DomainName+".awl.", dns.TypeA)
+	payload, err := query.Pack()
+	ts.NoError(err)
+
+	localIP, _ := peer1.app.Conf.VPNLocalIPMask()
+	const clientPort = 40000
+	queryPacket := testUDPPacket(localIP, dnsIP, clientPort, 53, payload)
+	peer1.tun.Outbound <- [][]byte{queryPacket}
+
+	timeout := time.After(10 * time.Second)
+	for {
+		var raw []byte
+		select {
+		case raw = <-inbound:
+		case <-timeout:
+			ts.FailNow("no DNS response arrived in TUN")
+		}
+
+		// Skip anything that is not a UDP packet from dnsIP:53 back to us.
+		const udpHeaderLen = 8
+		src, dst := parsePacketIPs(raw)
+		ipHeaderLen := int(raw[0]&0x0f) << 2
+		if raw[9] != vpn.IPProtocolUDP || len(raw) < ipHeaderLen+udpHeaderLen ||
+			!src.Equal(dnsIP) || !dst.Equal(localIP) {
+			continue
+		}
+		udpHeader := raw[ipHeaderLen:]
+		ts.Equal(uint16(53), binary.BigEndian.Uint16(udpHeader[0:2]))
+		ts.Equal(uint16(clientPort), binary.BigEndian.Uint16(udpHeader[2:4]))
+
+		resp := new(dns.Msg)
+		ts.NoError(resp.Unpack(udpHeader[udpHeaderLen:]))
+		ts.Equal(query.Id, resp.Id)
+		ts.Len(resp.Answer, 1)
+		aRecord, ok := resp.Answer[0].(*dns.A)
+		ts.True(ok)
+		ts.Equal(knownPeer.IPAddr, aRecord.A.String())
+		return
 	}
 }

--- a/awldns/awldns.go
+++ b/awldns/awldns.go
@@ -20,6 +20,9 @@ const (
 )
 
 const (
+	netUDP = "udp"
+	netTCP = "tcp"
+
 	LocalDomain               = "awl"
 	DefaultDNSAddress         = "127.0.0.66:53"
 	DefaultDNSPort            = "53"
@@ -34,8 +37,8 @@ type Resolver struct {
 	cfg       atomic.Pointer[config]
 	logger    *log.ZapEventLogger
 
-	udpServerWorking bool
-	tcpServerWorking bool
+	udpServerWorking atomic.Bool
+	tcpServerWorking atomic.Bool
 
 	dnsAddress string
 }
@@ -46,14 +49,41 @@ type config struct {
 	reverseMapping map[string]string
 }
 
+// NewResolver creates a resolver that binds its own UDP and TCP sockets on
+// dnsAddress (host:port).
 func NewResolver(dnsAddress string) *Resolver {
+	r := newResolver(dnsAddress)
+	r.udpServer.Addr = dnsAddress
+	r.udpServer.Net = netUDP
+	r.tcpServer.Addr = dnsAddress
+	r.tcpServer.Net = netTCP
+	r.startServers()
+
+	return r
+}
+
+// NewResolverFromListeners creates a resolver serving on already-open
+// listeners instead of binding sockets itself — used on Android, where :53
+// cannot be bound and the listeners live inside a netstack bridge
+// (awldns/dnsbridge). dnsAddress is what DNSAddress reports once both
+// servers are up; nothing is bound to it here.
+func NewResolverFromListeners(udpConn net.PacketConn, tcpListener net.Listener, dnsAddress string) *Resolver {
+	r := newResolver(dnsAddress)
+	r.udpServer.PacketConn = udpConn
+	r.tcpServer.Listener = tcpListener
+	r.startServers()
+
+	return r
+}
+
+func newResolver(dnsAddress string) *Resolver {
 	r := &Resolver{
 		logger: log.Logger("awl/dns"),
 		udpClient: &dns.Client{
-			Net: "udp",
+			Net: netUDP,
 		},
 		tcpClient: &dns.Client{
-			Net: "tcp",
+			Net: netTCP,
 		},
 		dnsAddress: dnsAddress,
 	}
@@ -65,39 +95,47 @@ func NewResolver(dnsAddress string) *Resolver {
 	mux.HandleFunc(".", r.dnsProxyHandler)
 
 	r.udpServer = &dns.Server{
-		Addr:    dnsAddress,
-		Net:     "udp",
 		Handler: mux,
 		NotifyStartedFunc: func() {
 			r.logger.Infof("udp server has started on %s", dnsAddress)
-			r.udpServerWorking = true
+			r.udpServerWorking.Store(true)
 		},
 	}
 	r.tcpServer = &dns.Server{
-		Addr:    dnsAddress,
-		Net:     "tcp",
 		Handler: mux,
 		NotifyStartedFunc: func() {
 			r.logger.Infof("tcp server has started on %s", dnsAddress)
-			r.tcpServerWorking = true
+			r.tcpServerWorking.Store(true)
 		},
 	}
+
+	return r
+}
+
+func (r *Resolver) startServers() {
 	go func() {
-		err := r.udpServer.ListenAndServe()
+		err := serveDNSServer(r.udpServer)
 		if err != nil {
 			r.logger.Errorf("serve udp server: %v", err)
 		}
-		r.udpServerWorking = false
+		r.udpServerWorking.Store(false)
 	}()
 	go func() {
-		err := r.tcpServer.ListenAndServe()
+		err := serveDNSServer(r.tcpServer)
 		if err != nil {
 			r.logger.Errorf("serve tcp server: %v", err)
 		}
-		r.tcpServerWorking = false
+		r.tcpServerWorking.Store(false)
 	}()
+}
 
-	return r
+// serveDNSServer serves srv either on a provided listener (PacketConn or
+// Listener set) or on a socket it binds itself (Addr and Net set).
+func serveDNSServer(srv *dns.Server) error {
+	if srv.PacketConn != nil || srv.Listener != nil {
+		return srv.ActivateAndServe()
+	}
+	return srv.ListenAndServe()
 }
 
 func (r *Resolver) ReceiveConfiguration(upstreamDNS string, namesMapping map[string]string) {
@@ -125,7 +163,7 @@ func (r *Resolver) ReceiveConfiguration(upstreamDNS string, namesMapping map[str
 }
 
 func (r *Resolver) DNSAddress() string {
-	if !r.tcpServerWorking || !r.udpServerWorking {
+	if !r.tcpServerWorking.Load() || !r.udpServerWorking.Load() {
 		return ""
 	}
 
@@ -278,7 +316,7 @@ func (r *Resolver) loadConfig() config {
 
 func processOwnResponse(req *dns.Msg, respWriter dns.ResponseWriter, resp *dns.Msg) {
 	maxSize := dns.MinMsgSize
-	if respWriter.LocalAddr().Network() == "tcp" {
+	if respWriter.LocalAddr().Network() == netTCP {
 		maxSize = dns.MaxMsgSize
 	} else {
 		if optRR := req.IsEdns0(); optRR != nil {

--- a/awldns/awldns_test.go
+++ b/awldns/awldns_test.go
@@ -139,6 +139,47 @@ func TestDNSUnknownAddressReturnsNameError(t *testing.T) {
 	a.Empty(resp.Answer)
 }
 
+func TestResolverFromListeners(t *testing.T) {
+	a := require.New(t)
+
+	udpConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	a.NoError(err)
+	tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	a.NoError(err)
+
+	// The reported address is decoupled from the listeners — on Android it is
+	// the in-tunnel DNS IP, while the listeners live inside netstack.
+	const dnsAddress = "10.66.255.254:53"
+	resolver := NewResolverFromListeners(udpConn, tcpListener, dnsAddress)
+	defer resolver.Close()
+
+	resolver.ReceiveConfiguration("", map[string]string{
+		"admin": "127.0.0.66",
+	})
+
+	// DNSAddress reports the passed address once both servers are serving.
+	a.Eventually(func() bool { return resolver.DNSAddress() == dnsAddress },
+		5*time.Second, 10*time.Millisecond)
+
+	req := new(dns.Msg)
+	req.SetQuestion("admin.awl.", dns.TypeA)
+
+	resp, _, err := new(dns.Client).Exchange(req, udpConn.LocalAddr().String())
+	a.NoError(err)
+	a.Len(resp.Answer, 1)
+	a.Equal("127.0.0.66", resp.Answer[0].(*dns.A).A.String())
+
+	tcpClient := &dns.Client{Net: "tcp"}
+	resp, _, err = tcpClient.Exchange(req, tcpListener.Addr().String())
+	a.NoError(err)
+	a.Len(resp.Answer, 1)
+	a.Equal("127.0.0.66", resp.Answer[0].(*dns.A).A.String())
+
+	resolver.Close()
+	a.Eventually(func() bool { return resolver.DNSAddress() == "" },
+		5*time.Second, 10*time.Millisecond)
+}
+
 func NewResolverClient(address string) *net.Resolver {
 	dialer := &net.Dialer{Timeout: time.Second}
 	return &net.Resolver{

--- a/awldns/dnsbridge/dnsbridge.go
+++ b/awldns/dnsbridge/dnsbridge.go
@@ -1,0 +1,173 @@
+// Package dnsbridge feeds IP packets intercepted from the VPN tunnel into a
+// userspace TCP/IP stack (gVisor, via the wireguard-go netstack wrapper) that
+// owns the in-tunnel DNS IP. It exists for platforms where awldns cannot bind
+// an OS socket on :53 (Android: ports below 1024 need root) — a regular DNS
+// server listens on dnsIP:53 (UDP and TCP) inside the stack through
+// UDPConn/TCPListener instead.
+//
+// The bridge is deliberately decoupled from the rest of awl: packets come in
+// through HandlePacket as raw bytes, responses leave through the writePacket
+// callback, and the DNS listeners are plain net.PacketConn/net.Listener.
+package dnsbridge
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/ipfs/go-log/v2"
+	"golang.zx2c4.com/wireguard/tun"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+
+	"github.com/anywherelan/awl/metrics"
+)
+
+const (
+	dnsPort = 53
+	// closeDrainDelay is how long Close lets the response pump drain packets
+	// already emitted by the stack before destroying it, see Close.
+	closeDrainDelay = 100 * time.Millisecond
+)
+
+type Bridge struct {
+	dnsIP       netip.Addr
+	mtu         int
+	dev         tun.Device
+	udpConn     net.PacketConn
+	tcpListener net.Listener
+	writePacket func(packet []byte) error
+
+	closed atomic.Bool
+	logger *log.ZapEventLogger
+}
+
+// New creates a bridge owning dnsIP, with listeners on dnsIP:53. writePacket
+// is called from a background goroutine with every IP packet the stack emits
+// (DNS responses, TCP control segments); the callee must not retain the
+// slice. mtu should match the VPN interface MTU.
+func New(dnsIP netip.Addr, mtu int, writePacket func(packet []byte) error) (*Bridge, error) {
+	dev, nsNet, err := netstack.CreateNetTUN([]netip.Addr{dnsIP}, nil, mtu)
+	if err != nil {
+		return nil, fmt.Errorf("create netstack: %v", err)
+	}
+	udpConn, err := nsNet.ListenUDPAddrPort(netip.AddrPortFrom(dnsIP, dnsPort))
+	if err != nil {
+		_ = dev.Close()
+		return nil, fmt.Errorf("netstack: listen udp on %s: %v", netip.AddrPortFrom(dnsIP, dnsPort), err)
+	}
+	tcpListener, err := nsNet.ListenTCPAddrPort(netip.AddrPortFrom(dnsIP, dnsPort))
+	if err != nil {
+		_ = udpConn.Close()
+		_ = dev.Close()
+		return nil, fmt.Errorf("netstack: listen tcp on %s: %v", netip.AddrPortFrom(dnsIP, dnsPort), err)
+	}
+
+	b := &Bridge{
+		dnsIP:       dnsIP,
+		mtu:         mtu,
+		dev:         dev,
+		udpConn:     udpConn,
+		tcpListener: tcpListener,
+		writePacket: writePacket,
+		logger:      log.Logger("awl/dnsbridge"),
+	}
+	go b.readResponses()
+
+	return b, nil
+}
+
+// DNSIP returns the in-tunnel IP the bridge answers on.
+func (b *Bridge) DNSIP() netip.Addr {
+	return b.dnsIP
+}
+
+// UDPConn is the bridge-side UDP listener on dnsIP:53, to be served by a DNS
+// server (e.g. dns.Server{PacketConn: ...} with ActivateAndServe).
+func (b *Bridge) UDPConn() net.PacketConn {
+	return b.udpConn
+}
+
+// TCPListener is the bridge-side TCP listener on dnsIP:53.
+func (b *Bridge) TCPListener() net.Listener {
+	return b.tcpListener
+}
+
+// HandlePacket injects an IP packet addressed to the DNS IP into the stack.
+// The packet data is copied — the caller may reuse its buffer immediately.
+// Safe to call concurrently with Close (packets are dropped after close).
+func (b *Bridge) HandlePacket(packet []byte) {
+	if b.closed.Load() || len(packet) == 0 {
+		return
+	}
+	metrics.DNSInterceptPacketsTotal.Inc()
+	// Defensive clone: our caller (the TUN read loop) reuses its buffers, so
+	// the packet must not be aliased past this call. netstack's Write currently
+	// copies the data into its own storage (buffer.MakeWithData), so this clone
+	// is technically redundant today — but we don't want correctness to depend
+	// on that gVisor internal staying copy-on-write across upstream bumps.
+	_, err := b.dev.Write([][]byte{bytes.Clone(packet)}, 0)
+	if err != nil {
+		metrics.DNSInterceptDroppedTotal.WithLabelValues("netstack_write").Inc()
+		b.logger.Debugf("write packet to netstack: %v", err)
+	}
+}
+
+// Close shuts the bridge down: the listeners stop accepting, the stack is
+// destroyed and the response-reading goroutine exits. Idempotent. The DNS
+// servers running on the listeners should be shut down by their owner first;
+// closing the listeners here is a safety net.
+func (b *Bridge) Close() {
+	if !b.closed.CompareAndSwap(false, true) {
+		return
+	}
+	_ = b.udpConn.Close()
+	_ = b.tcpListener.Close()
+	// Upstream race in wireguard-go netstack: the stack delivers outgoing
+	// packets via a blocking send to an unbuffered channel (netTun.WriteNotify),
+	// and netTun.Close closes that channel without waiting for in-flight sends —
+	// a send racing the close panics the process. Closing the stack itself
+	// aborts live TCP endpoints, which emits RSTs into exactly that path. The
+	// closed flag (no new injected packets) plus the closed listeners stop new
+	// traffic, and keeping the pump draining for a moment lets already-emitted
+	// packets through — shrinking the window to almost nothing, though not to
+	// zero.
+	time.Sleep(closeDrainDelay)
+	// Unblocks the pending Read in readResponses.
+	_ = b.dev.Close()
+}
+
+// readResponses pumps packets emitted by the stack into writePacket until the
+// bridge is closed.
+func (b *Bridge) readResponses() {
+	// netstack's BatchSize is 1: single buffer, one packet per Read.
+	bufs := [][]byte{make([]byte, b.mtu)}
+	sizes := make([]int, 1)
+	for {
+		n, err := b.dev.Read(bufs, sizes, 0)
+		if err != nil {
+			// os.ErrClosed is the normal shutdown path.
+			if b.closed.Load() || errors.Is(err, os.ErrClosed) {
+				return
+			}
+			// A transient per-packet error must not kill the pump: the bridge
+			// would still look alive while device DNS silently went dead.
+			b.logger.Errorf("read from netstack: %v", err)
+			continue
+		}
+		for i := 0; i < n; i++ {
+			if sizes[i] == 0 {
+				continue
+			}
+			writeErr := b.writePacket(bufs[i][:sizes[i]])
+			if writeErr != nil {
+				metrics.DNSInterceptDroppedTotal.WithLabelValues("tun_write").Inc()
+				b.logger.Debugf("write response packet: %v", writeErr)
+			}
+		}
+	}
+}

--- a/awldns/dnsbridge/dnsbridge_test.go
+++ b/awldns/dnsbridge/dnsbridge_test.go
@@ -1,0 +1,194 @@
+package dnsbridge_test
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+
+	"github.com/anywherelan/awl/awldns/dnsbridge"
+)
+
+const (
+	testMTU = 3500
+	// answerIP is what the test DNS handler returns for any A question.
+	answerIP = "10.66.0.2"
+)
+
+var (
+	clientIP = netip.MustParseAddr("10.66.0.1")
+	dnsIP    = netip.MustParseAddr("10.66.255.254")
+)
+
+// testEnv wires a Bridge to a second netstack acting as the querying client:
+// packets the client stack emits are fed into Bridge.HandlePacket (through a
+// reused buffer — exercising HandlePacket's copy semantics), and packets the
+// bridge emits are injected back into the client stack. A dns.Server with a
+// static A-record handler serves the bridge listeners, mirroring how awldns
+// will use them.
+type testEnv struct {
+	bridge    *dnsbridge.Bridge
+	clientNet *netstack.Net
+}
+
+func newTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+
+	clientDev, clientNet, err := netstack.CreateNetTUN([]netip.Addr{clientIP}, nil, testMTU)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientDev.Close() })
+
+	bridge, err := dnsbridge.New(dnsIP, testMTU, func(packet []byte) error {
+		_, writeErr := clientDev.Write([][]byte{bytes.Clone(packet)}, 0)
+		return writeErr
+	})
+	require.NoError(t, err)
+	t.Cleanup(bridge.Close)
+
+	// Client stack → bridge. The single read buffer is deliberately reused
+	// between iterations: HandlePacket must copy the data.
+	go func() {
+		bufs := [][]byte{make([]byte, testMTU)}
+		sizes := make([]int, 1)
+		for {
+			n, readErr := clientDev.Read(bufs, sizes, 0)
+			if readErr != nil {
+				return
+			}
+			for i := 0; i < n; i++ {
+				bridge.HandlePacket(bufs[i][:sizes[i]])
+			}
+		}
+	}()
+
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		for _, q := range r.Question {
+			if q.Qtype != dns.TypeA {
+				continue
+			}
+			m.Answer = append(m.Answer, &dns.A{
+				Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+				A:   net.ParseIP(answerIP).To4(),
+			})
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	udpServer := &dns.Server{PacketConn: bridge.UDPConn(), Handler: handler}
+	go func() { _ = udpServer.ActivateAndServe() }()
+	tcpServer := &dns.Server{Listener: bridge.TCPListener(), Handler: handler}
+	go func() { _ = tcpServer.ActivateAndServe() }()
+	t.Cleanup(func() {
+		_ = udpServer.Shutdown()
+		_ = tcpServer.Shutdown()
+	})
+
+	return &testEnv{bridge: bridge, clientNet: clientNet}
+}
+
+func (e *testEnv) exchange(t *testing.T, network, domain string) *dns.Msg {
+	t.Helper()
+
+	var conn net.Conn
+	var err error
+	switch network {
+	case "udp":
+		conn, err = e.clientNet.DialUDPAddrPort(netip.AddrPort{}, netip.AddrPortFrom(dnsIP, 53))
+	case "tcp":
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		conn, err = e.clientNet.DialContextTCPAddrPort(ctx, netip.AddrPortFrom(dnsIP, 53))
+	default:
+		t.Fatalf("unknown network %q", network)
+	}
+	require.NoError(t, err)
+	defer conn.Close()
+
+	dnsConn := &dns.Conn{Conn: conn}
+	require.NoError(t, dnsConn.SetDeadline(time.Now().Add(5*time.Second)))
+
+	query := new(dns.Msg)
+	query.SetQuestion(dns.Fqdn(domain), dns.TypeA)
+	require.NoError(t, dnsConn.WriteMsg(query))
+	resp, err := dnsConn.ReadMsg()
+	require.NoError(t, err)
+	require.Equal(t, query.Id, resp.Id)
+
+	return resp
+}
+
+func TestExchangeUDP(t *testing.T) {
+	env := newTestEnv(t)
+
+	resp := env.exchange(t, "udp", "peer.awl")
+	require.Len(t, resp.Answer, 1)
+	require.Equal(t, answerIP, resp.Answer[0].(*dns.A).A.String())
+}
+
+func TestExchangeTCP(t *testing.T) {
+	env := newTestEnv(t)
+
+	resp := env.exchange(t, "tcp", "peer.awl")
+	require.Len(t, resp.Answer, 1)
+	require.Equal(t, answerIP, resp.Answer[0].(*dns.A).A.String())
+}
+
+func TestSequentialQueries(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Several exchanges through the same reused client-side read buffer:
+	// catches data corruption if HandlePacket ever stops copying.
+	for i := 0; i < 10; i++ {
+		resp := env.exchange(t, "udp", "peer.awl")
+		require.Len(t, resp.Answer, 1)
+		require.Equal(t, answerIP, resp.Answer[0].(*dns.A).A.String())
+	}
+}
+
+// TestClosedPortRejectedQuickly verifies the stack answers TCP SYN to a
+// non-listening port with RST instead of silently dropping it — this is what
+// makes Android Private DNS "Automatic" probes (DoT on :853) fail fast and
+// fall back to plain DNS.
+func TestClosedPortRejectedQuickly(t *testing.T) {
+	env := newTestEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := env.clientNet.DialContextTCPAddrPort(ctx, netip.AddrPortFrom(dnsIP, 853))
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	require.NoError(t, ctx.Err(), "expected connection refused, got timeout after %s", elapsed)
+	require.Less(t, elapsed, 2*time.Second)
+}
+
+func TestCloseIdempotentAndSafe(t *testing.T) {
+	bridge, err := dnsbridge.New(dnsIP, testMTU, func([]byte) error { return nil })
+	require.NoError(t, err)
+
+	bridge.Close()
+	bridge.Close()
+	// Packets after close are silently dropped.
+	bridge.HandlePacket([]byte{0x45, 0x00})
+}
+
+func TestDNSIP(t *testing.T) {
+	bridge, err := dnsbridge.New(dnsIP, testMTU, func([]byte) error { return nil })
+	require.NoError(t, err)
+	t.Cleanup(bridge.Close)
+
+	require.Equal(t, dnsIP, bridge.DNSIP())
+}

--- a/cmd/awl-tray/go.mod
+++ b/cmd/awl-tray/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.30.3 // indirect
+	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -165,7 +166,7 @@ require (
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
+	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/image v0.39.0 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
@@ -181,7 +182,8 @@ require (
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	honnef.co/go/tools v0.4.5 // indirect
+	gvisor.dev/gvisor v0.0.0-20250503011706-39ed1f5ac29c // indirect
+	honnef.co/go/tools v0.5.1 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 	rsc.io/qr v0.2.0 // indirect
 )

--- a/cmd/awl-tray/go.sum
+++ b/cmd/awl-tray/go.sum
@@ -630,8 +630,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
-golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a h1:Jw5wfR+h9mnIYH+OtGT2im5wV1YGGDora5vTv/aa5bE=
-golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
@@ -1013,8 +1013,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.4.5 h1:YGD4H+SuIOOqsyoLOpZDWcieM28W47/zRO7f+9V3nvo=
-honnef.co/go/tools v0.4.5/go.mod h1:GUV+uIBCLpdf0/v6UhHHG/yzI/z6qPskBeQCjcNB96k=
+honnef.co/go/tools v0.5.1 h1:4bH5o3b5ZULQ4UrBmP+63W9r7qIkqJClEA9ko5YKx+I=
+honnef.co/go/tools v0.5.1/go.mod h1:e9irvo83WDG9/irijV44wr3tbhcFeRnfpVlRqVwpzMs=
 lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
 lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/cmd/gomobile-lib/main.go
+++ b/cmd/gomobile-lib/main.go
@@ -164,3 +164,35 @@ func GetApiAddress() string {
 	}
 	return ""
 }
+
+// DnsServerIP returns the in-tunnel IP the host app must pass to
+// VpnService.Builder.addDnsServer when DNS is enabled in the config. Call
+// after Setup; normally before StartServer (establishTun runs first), in
+// which case the address is computed from the saved config. When the server
+// is already running (the reconfigure_vpn flow), the address of the active
+// interceptor is returned instead, so the host cannot diverge from the core.
+// An empty string means DNS must not be configured: no free IP in the VPN
+// subnet, or the running server has no active interceptor.
+func DnsServerIP() string {
+	if globalApp != nil && globalApp.Dns != nil {
+		ip := globalApp.Dns.NetstackDNSServerIP()
+		if ip == nil {
+			return ""
+		}
+		return ip.String()
+	}
+
+	if globalDataDir == "" {
+		panic("call to DnsServerIP before Setup")
+	}
+
+	conf, loadConfigErr := config.LoadConfig(appType, eventbus.NewBus())
+	if loadConfigErr != nil {
+		conf = config.NewConfig(appType, eventbus.NewBus())
+	}
+	ip := conf.NetstackDNSIP()
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"sync"
@@ -44,6 +45,14 @@ type (
 		dataDir      string
 		emitter      awlevent.Emitter
 		appType      AppType
+		// netstackDNSIP is the in-subnet IP reserved for the awl DNS server:
+		// broadcast−1 shifted down past taken addresses. Computed once in
+		// setDefaults from the config snapshot (not serialized), fixed for the
+		// session. Reserved on every platform so it is never handed to a peer
+		// (see CheckIPUnique), though only the Android netstack DNS interceptor
+		// (awldns/dnsbridge) actually serves on it today; kept reserved on
+		// desktop for a future userspace-netstack path.
+		netstackDNSIP net.IP
 
 		Version               string                 `json:"version"`
 		LoggerLevel           string                 `json:"loggerLevel"`

--- a/config/network_addr.go
+++ b/config/network_addr.go
@@ -29,6 +29,47 @@ func (c *Config) VPNLocalIPMaskUnlocked() (net.IP, net.IPMask) {
 	return localIP.To4(), ipNet.Mask
 }
 
+// NetstackDNSIP returns the in-subnet IP reserved for the awl DNS server,
+// computed once in setDefaults and fixed for the session (see the
+// netstackDNSIP field). nil when the subnet has no free address, in which case
+// DNS is disabled. Used on Android, where DNS queries to it are intercepted
+// inside the tunnel.
+func (c *Config) NetstackDNSIP() net.IP {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.netstackDNSIP
+}
+
+// computeNetstackDNSIP derives the reserved DNS server IP from the current
+// config snapshot: broadcast−1, shifted down until an address is free to
+// assign (CheckIPUnique rejects our own IP, the broadcast address and peers).
+// Deterministic; returns nil when the subnet has no free address. Not thread
+// safe — called from setDefaults at construction only, where netstackDNSIP is
+// still nil, so CheckIPUnique's own DNS-reservation check is a no-op here and
+// cannot recurse. The result is cached in netstackDNSIP and read everywhere
+// else via NetstackDNSIP.
+func (c *Config) computeNetstackDNSIP() net.IP {
+	localIP, netMask := c.VPNLocalIPMaskUnlocked()
+	if localIP == nil {
+		return nil
+	}
+	ipNet := &net.IPNet{
+		IP:   localIP.Mask(netMask),
+		Mask: netMask,
+	}
+	network, broadcast := subnetBounds(ipNet)
+
+	for candidate := broadcast - 1; candidate > network; candidate-- {
+		ip := uint32ToIPAddr(candidate)
+		if c.CheckIPUnique(ip.String(), "") == nil {
+			return ip
+		}
+	}
+
+	return nil
+}
+
 // GenerateNextIpAddr is not thread safe.
 func (c *Config) GenerateNextIpAddr() string {
 	return c.GenerateNextIpAddrExcept(nil)
@@ -61,12 +102,17 @@ func (c *Config) GenerateNextIpAddrExcept(except []string) string {
 		exceptMap[ip] = struct{}{}
 	}
 
-	// Find next available IP that is not in exceptMap
+	// Reserved addresses that must never be handed out to a peer.
+	_, broadcast := subnetBounds(ipNet)
+
+	// Find next available IP that is not in exceptMap and not reserved
 	for {
 		newIp := incrementIPAddr(maxIp)
 		newIpStr := newIp.String()
 
-		if _, excluded := exceptMap[newIpStr]; !excluded {
+		_, excluded := exceptMap[newIpStr]
+		reserved := binary.BigEndian.Uint32(newIp) == broadcast || newIp.Equal(c.netstackDNSIP)
+		if !excluded && !reserved {
 			return newIpStr
 		}
 
@@ -96,6 +142,16 @@ func (c *Config) CheckIPUnique(checkIP string, exceptPeerID string) error {
 		return fmt.Errorf("IP %s does not belong to subnet %s", checkIP, ipNet)
 	}
 
+	if _, broadcast := subnetBounds(ipNet); binary.BigEndian.Uint32(ip) == broadcast {
+		return fmt.Errorf("IP %s is the broadcast address of subnet %s", checkIP, ipNet)
+	}
+	if ip.Equal(localIP) {
+		return fmt.Errorf("IP %s is the local node's own address", checkIP)
+	}
+	if ip.Equal(c.netstackDNSIP) {
+		return fmt.Errorf("IP %s is reserved for the awl DNS server", checkIP)
+	}
+
 	for _, peer := range c.KnownPeers {
 		if peer.IPAddr != checkIP {
 			continue
@@ -111,12 +167,19 @@ func (c *Config) CheckIPUnique(checkIP string, exceptPeerID string) error {
 }
 
 func incrementIPAddr(ip net.IP) net.IP {
-	i := binary.BigEndian.Uint32(ip)
-	i++
+	return uint32ToIPAddr(binary.BigEndian.Uint32(ip) + 1)
+}
 
+func uint32ToIPAddr(i uint32) net.IP {
 	bs := make([]byte, 4)
 	binary.BigEndian.PutUint32(bs, i)
 
-	ipNew := net.IP(bs)
-	return ipNew
+	return bs
+}
+
+// subnetBounds returns the IPv4 network and broadcast addresses of ipNet.
+func subnetBounds(ipNet *net.IPNet) (network, broadcast uint32) {
+	network = binary.BigEndian.Uint32(ipNet.IP.Mask(ipNet.Mask))
+	broadcast = network | ^binary.BigEndian.Uint32(ipNet.Mask)
+	return network, broadcast
 }

--- a/config/network_addr_test.go
+++ b/config/network_addr_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -101,6 +102,85 @@ func TestGenerateNextIpAddrExcept(t *testing.T) {
 		ip := conf.GenerateNextIpAddrExcept(exceptions)
 		assert.Equal(t, "10.66.0.22", ip)
 	})
+
+	t.Run("SkipsNetstackDNSIP", func(t *testing.T) {
+		conf := &Config{
+			VPNConfig: VPNConfig{IPNet: DefaultVPNNetworkSubnet},
+			KnownPeers: map[string]KnownPeer{
+				"p": {PeerID: "p", IPAddr: "10.66.0.10"},
+			},
+		}
+		conf.netstackDNSIP = net.ParseIP("10.66.0.11").To4()
+
+		ip := conf.GenerateNextIpAddrExcept(nil)
+		assert.Equal(t, "10.66.0.12", ip)
+	})
+
+	t.Run("SkipsNetstackDNSIPAndBroadcast", func(t *testing.T) {
+		// 10.66.0.1/29: hosts .1 (local) — .6, broadcast .7, DNS IP .6.
+		conf := &Config{
+			VPNConfig: VPNConfig{IPNet: "10.66.0.1/29"},
+			KnownPeers: map[string]KnownPeer{
+				"p": {PeerID: "p", IPAddr: "10.66.0.5"},
+			},
+		}
+		conf.netstackDNSIP = conf.computeNetstackDNSIP()
+
+		// Next after max (.5) would be .6 (DNS IP, skipped) and .7 (broadcast,
+		// skipped). Walking past the end of an exhausted subnet is pre-existing
+		// behavior of this function, not introduced by the reserved addresses.
+		ip := conf.GenerateNextIpAddrExcept(nil)
+		assert.Equal(t, "10.66.0.8", ip)
+	})
+}
+
+func TestDNSServerIP(t *testing.T) {
+	makeConf := func(ipNet string, peerIPs ...string) *Config {
+		conf := &Config{
+			VPNConfig:  VPNConfig{IPNet: ipNet},
+			KnownPeers: map[string]KnownPeer{},
+		}
+		for _, ip := range peerIPs {
+			conf.KnownPeers[ip] = KnownPeer{PeerID: "peer-" + ip, IPAddr: ip}
+		}
+		return conf
+	}
+
+	t.Run("DefaultSubnet", func(t *testing.T) {
+		conf := makeConf(DefaultVPNNetworkSubnet)
+		assert.Equal(t, "10.66.255.254", conf.computeNetstackDNSIP().String())
+	})
+
+	t.Run("CandidateTakenByPeer", func(t *testing.T) {
+		conf := makeConf(DefaultVPNNetworkSubnet, "10.66.255.254")
+		assert.Equal(t, "10.66.255.253", conf.computeNetstackDNSIP().String())
+	})
+
+	t.Run("SeveralCandidatesTakenByPeers", func(t *testing.T) {
+		conf := makeConf(DefaultVPNNetworkSubnet, "10.66.255.254", "10.66.255.253")
+		assert.Equal(t, "10.66.255.252", conf.computeNetstackDNSIP().String())
+	})
+
+	t.Run("CandidateTakenByOwnIP", func(t *testing.T) {
+		conf := makeConf("10.66.255.254/16")
+		assert.Equal(t, "10.66.255.253", conf.computeNetstackDNSIP().String())
+	})
+
+	t.Run("ExhaustedSubnet", func(t *testing.T) {
+		// 10.66.0.1/30: only hosts are .1 (local) and .2 (peer).
+		conf := makeConf("10.66.0.1/30", "10.66.0.2")
+		assert.Nil(t, conf.computeNetstackDNSIP())
+	})
+
+	t.Run("PointToPointSubnet", func(t *testing.T) {
+		conf := makeConf("10.66.0.1/31")
+		assert.Nil(t, conf.computeNetstackDNSIP())
+	})
+
+	t.Run("InvalidSubnet", func(t *testing.T) {
+		conf := makeConf("not-a-cidr")
+		assert.Nil(t, conf.computeNetstackDNSIP())
+	})
 }
 
 func TestCheckIPUnique(t *testing.T) {
@@ -113,6 +193,7 @@ func TestCheckIPUnique(t *testing.T) {
 			"p2": {PeerID: "p2", IPAddr: "10.66.0.2", Alias: "peer2"},
 		},
 	}
+	conf.netstackDNSIP = conf.computeNetstackDNSIP()
 
 	tests := []struct {
 		name         string
@@ -125,6 +206,8 @@ func TestCheckIPUnique(t *testing.T) {
 		{"SamePeerIP", "10.66.0.1", "p1", ""},
 		{"InvalidIPFormat", "invalid", "", "invalid IP invalid"},
 		{"OutsideSubnet", "192.168.1.1", "", "IP 192.168.1.1 does not belong to subnet 10.66.0.0/16"},
+		{"BroadcastAddress", "10.66.255.255", "", "IP 10.66.255.255 is the broadcast address of subnet 10.66.0.0/16"},
+		{"DNSServerIP", "10.66.255.254", "", "IP 10.66.255.254 is reserved for the awl DNS server"},
 	}
 
 	for _, tt := range tests {
@@ -138,4 +221,50 @@ func TestCheckIPUnique(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("LocalNodeIPRejected", func(t *testing.T) {
+		conf := &Config{
+			VPNConfig:  VPNConfig{IPNet: "10.66.0.1/16"},
+			KnownPeers: map[string]KnownPeer{},
+		}
+		conf.netstackDNSIP = conf.computeNetstackDNSIP()
+
+		assert.ErrorContains(t, conf.CheckIPUnique("10.66.0.1", ""), "own address")
+		assert.NoError(t, conf.CheckIPUnique("10.66.0.2", ""))
+	})
+
+	t.Run("NetstackDNSIPReserved", func(t *testing.T) {
+		// Only the fixed netstackDNSIP is reserved: here the interceptor serves
+		// on broadcast−2 (e.g. broadcast−1 was taken at startup, then freed), so
+		// broadcast−2 is rejected while broadcast−1 is a normal free address.
+		conf := &Config{
+			VPNConfig:  VPNConfig{IPNet: "10.66.0.0/16"},
+			KnownPeers: map[string]KnownPeer{},
+		}
+		conf.netstackDNSIP = net.ParseIP("10.66.255.253").To4()
+
+		assert.ErrorContains(t, conf.CheckIPUnique("10.66.255.253", ""), "reserved for the awl DNS server")
+		assert.NoError(t, conf.CheckIPUnique("10.66.255.254", ""))
+		assert.NoError(t, conf.CheckIPUnique("10.66.255.252", ""))
+
+		conf.netstackDNSIP = nil
+		assert.NoError(t, conf.CheckIPUnique("10.66.255.253", ""))
+	})
+
+	t.Run("ShiftedDNSServerIP", func(t *testing.T) {
+		// A peer already holds broadcast−1 (e.g. from an old config), so the
+		// DNS IP shifts to broadcast−2: the peer keeps its IP, the shifted
+		// reserved address is rejected.
+		conf := &Config{
+			VPNConfig: VPNConfig{IPNet: "10.66.0.0/16"},
+			KnownPeers: map[string]KnownPeer{
+				"p1": {PeerID: "p1", IPAddr: "10.66.255.254", Alias: "peer1"},
+			},
+		}
+		conf.netstackDNSIP = conf.computeNetstackDNSIP()
+
+		assert.NoError(t, conf.CheckIPUnique("10.66.255.254", "p1"))
+		assert.ErrorContains(t, conf.CheckIPUnique("10.66.255.254", ""), "already used by peer peer1")
+		assert.ErrorContains(t, conf.CheckIPUnique("10.66.255.253", ""), "reserved for the awl DNS server")
+	})
 }

--- a/config/other.go
+++ b/config/other.go
@@ -206,6 +206,11 @@ func setDefaults(conf *Config, bus awlevent.Bus) {
 	if conf.KnownPeers == nil {
 		conf.KnownPeers = make(map[string]KnownPeer)
 	}
+
+	// Reserve the netstack DNS IP before assigning peer IPs below, so a peer cannot be handed it.
+	// Computed once here, fixed for the session, recomputed on every load.
+	conf.netstackDNSIP = conf.computeNetstackDNSIP()
+
 	for peerID := range conf.KnownPeers {
 		peer := conf.KnownPeers[peerID]
 		newAlias := conf.genUniqPeerAlias(peer.Name, peer.Alias, uniqAliases)

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/godbus/dbus/v5 v5.1.1-0.20230522191255-76236955d466 // indirect
+	github.com/google/btree v1.1.2 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
@@ -154,7 +155,7 @@ require (
 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a // indirect
+	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6 // indirect
@@ -166,7 +167,8 @@ require (
 	gonum.org/v1/gonum v0.17.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	honnef.co/go/tools v0.4.5 // indirect
+	gvisor.dev/gvisor v0.0.0-20250503011706-39ed1f5ac29c // indirect
+	honnef.co/go/tools v0.5.1 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 	rsc.io/qr v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -590,8 +590,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
-golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a h1:Jw5wfR+h9mnIYH+OtGT2im5wV1YGGDora5vTv/aa5bE=
-golang.org/x/exp/typeparams v0.0.0-20221208152030-732eee02a75a/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -973,8 +973,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.4.5 h1:YGD4H+SuIOOqsyoLOpZDWcieM28W47/zRO7f+9V3nvo=
-honnef.co/go/tools v0.4.5/go.mod h1:GUV+uIBCLpdf0/v6UhHHG/yzI/z6qPskBeQCjcNB96k=
+honnef.co/go/tools v0.5.1 h1:4bH5o3b5ZULQ4UrBmP+63W9r7qIkqJClEA9ko5YKx+I=
+honnef.co/go/tools v0.5.1/go.mod h1:e9irvo83WDG9/irijV44wr3tbhcFeRnfpVlRqVwpzMs=
 lukechampine.com/blake3 v1.4.1 h1:I3Smz7gso8w4/TunLKec6K2fn+kyKtDxr/xcQEN84Wg=
 lukechampine.com/blake3 v1.4.1/go.mod h1:QFosUxmjB8mnrWFSNwKmvxHpfY72bmD2tQ0kBMM3kwo=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/metrics/dns.go
+++ b/metrics/dns.go
@@ -27,4 +27,18 @@ var (
 		Help:      "DNS query duration in seconds.",
 		Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 10},
 	})
+
+	DNSInterceptPacketsTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "dns",
+		Name:      "intercept_packets_total",
+		Help:      "Total IP packets intercepted from the tunnel into the DNS netstack bridge.",
+	})
+
+	DNSInterceptDroppedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "dns",
+		Name:      "intercept_dropped_total",
+		Help:      "Total DNS bridge packets dropped, by reason.",
+	}, []string{"reason"})
 )

--- a/service/tunnel.go
+++ b/service/tunnel.go
@@ -52,6 +52,22 @@ type Tunnel struct {
 	// on real transitions (they run on every libp2p per-stream event).
 	gatewayConnEmitter  awlevent.Emitter
 	vpnGatewayConnected atomic.Bool
+
+	// dnsHandler, when set, receives packets addressed to the in-tunnel DNS IP
+	// (the Android DNS interceptor). atomic.Pointer because the Tunnel is
+	// created before the DNS service that installs the handler.
+	dnsHandler atomic.Pointer[dnsHandler]
+}
+
+// DNSPacketHandler receives IP packets addressed to the in-tunnel DNS IP.
+// HandlePacket must copy the packet data: the caller reuses the buffer.
+type DNSPacketHandler interface {
+	HandlePacket(packet []byte)
+}
+
+type dnsHandler struct {
+	ip      net.IP
+	handler DNSPacketHandler
 }
 
 func NewTunnel(p2pService P2p, device *vpn.Device, conf *config.Config, eventbus awlevent.Bus) *Tunnel {
@@ -80,6 +96,12 @@ func NewTunnel(p2pService P2p, device *vpn.Device, conf *config.Config, eventbus
 	p2pService.SubscribeConnectionEvents(tunnel.onPeerConnected, tunnel.onPeerDisconnected)
 
 	return tunnel
+}
+
+// SetDNSHandler installs h as the receiver of packets addressed to dnsIP.
+// Safe to call concurrently with HandleReadPackets.
+func (t *Tunnel) SetDNSHandler(dnsIP net.IP, h DNSPacketHandler) {
+	t.dnsHandler.Store(&dnsHandler{ip: dnsIP, handler: h})
 }
 
 func (t *Tunnel) StreamHandler(stream network.Stream) {
@@ -241,6 +263,7 @@ func (t *Tunnel) HandleReadPackets(packets []*vpn.Packet) {
 	if t.isClosed.Load() {
 		return
 	}
+	dnsIntercept := t.dnsHandler.Load()
 
 	for i, packet := range packets {
 		if packet == nil {
@@ -248,6 +271,13 @@ func (t *Tunnel) HandleReadPackets(packets []*vpn.Packet) {
 		}
 		// TODO: ipv6 support
 		if packet.IsIPv6 {
+			continue
+		}
+
+		// DNS queries to the in-tunnel DNS IP (Android interceptor). Must come
+		// before the broadcast and gateway branches.
+		if dnsIntercept != nil && packet.Dst.Equal(dnsIntercept.ip) {
+			dnsIntercept.handler.HandlePacket(packet.Packet)
 			continue
 		}
 

--- a/test_suite_test.go
+++ b/test_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -591,6 +592,35 @@ func testPacketWithSrcDest(length int, srcIP, destIP string) []byte {
 
 func testPacketWithDest(length int, destIP string) []byte {
 	return testPacketWithSrcDest(length, "10.66.0.1", destIP)
+}
+
+// testUDPPacket builds an IPv4/UDP packet with the given payload and correct
+// checksums (e.g. a DNS query for the interceptor tests).
+func testUDPPacket(srcIP, dstIP net.IP, srcPort, dstPort uint16, payload []byte) []byte {
+	const ipHeaderLen = 20
+	const udpHeaderLen = 8
+	raw := make([]byte, ipHeaderLen+udpHeaderLen+len(payload))
+	raw[0] = 0x45 // IPv4, IHL 5
+	binary.BigEndian.PutUint16(raw[2:], uint16(len(raw)))
+	raw[8] = 64 // TTL
+	raw[9] = vpn.IPProtocolUDP
+	copy(raw[12:16], srcIP.To4())
+	copy(raw[16:20], dstIP.To4())
+	binary.BigEndian.PutUint16(raw[20:], srcPort)
+	binary.BigEndian.PutUint16(raw[22:], dstPort)
+	binary.BigEndian.PutUint16(raw[24:], uint16(udpHeaderLen+len(payload)))
+	copy(raw[28:], payload)
+
+	pkt := vpn.Packet{}
+	if _, err := pkt.ReadFrom(bytes.NewReader(raw)); err != nil {
+		panic(err)
+	}
+	if !pkt.Parse() {
+		panic("failed to parse built UDP packet")
+	}
+	pkt.RecalculateChecksum()
+
+	return append([]byte{}, pkt.Packet...)
 }
 
 // parsePacketIPs extracts src and dst IPs from a raw IPv4 packet.

--- a/vpn/iface_windows.go
+++ b/vpn/iface_windows.go
@@ -64,10 +64,10 @@ func newTUN(ifname string, mtu int, localIP net.IP, ipMask net.IPMask) (tun.Devi
 	if err := setInterfaceMTU(logger, luid, winipcfg.AddressFamily(windows.AF_INET), uint32(mtu)); err != nil {
 		return nil, fmt.Errorf("set IPv4 MTU on tun: %v", err)
 	}
-	// TODO: support ipv6. Forwarding still ignores IPv6 packets (see Device.WritePacket),
-	// but we set the system MTU best-effort so the interface is configured correctly once
-	// IPv6 lands. On hosts with IPv6 disabled on the interface this Set() fails — that's
-	// expected, not fatal.
+	// TODO: support ipv6. Forwarding still ignores IPv6 packets (dropped in
+	// Tunnel.HandleReadPackets), but we set the system MTU best-effort so the
+	// interface is configured correctly once IPv6 lands. On hosts with IPv6
+	// disabled on the interface this Set() fails — that's expected, not fatal.
 	if err := setInterfaceMTU(logger, luid, winipcfg.AddressFamily(windows.AF_INET6), uint32(mtu)); err != nil {
 		logger.Warnf("set IPv6 MTU on tun (best-effort, ipv6 unused by awl): %v", err)
 	}

--- a/vpn/vpn.go
+++ b/vpn/vpn.go
@@ -77,30 +77,25 @@ func (d *Device) PutTempPacket(data *Packet) {
 	d.packetsPool.Put(data)
 }
 
-func (d *Device) WritePacket(data *Packet, senderIP net.IP) error {
-	if data.IsIPv6 {
-		// TODO: implement. We need to set Device.localIP ipv6 instead of ipv4
-		return nil
-	} else {
-		copy(data.Src, senderIP)
-		copy(data.Dst, d.localIP)
-	}
-	data.RecalculateChecksum()
-
-	bufs := [][]byte{data.Buf()}
-	packetsCount, err := d.tun.Write(bufs, tunPacketOffset)
-	if err != nil {
-		return fmt.Errorf("write packet to tun: %v", err)
-	} else if packetsCount < len(bufs) {
-		d.logger.Warnf("wrote %d packets, len(bufs): %d", packetsCount, len(bufs))
-	}
-
-	return nil
-}
-
 // LocalIP returns the awl IP assigned to this device. Set once in NewDevice.
 func (d *Device) LocalIP() net.IP {
 	return d.localIP
+}
+
+// WriteRawPacket writes a single ready-made IP packet (raw bytes, not a
+// *Packet) to the TUN device, framing it with the internal TUN header offset.
+// The slice is not retained. Used by the DNS bridge to inject netstack-emitted packets.
+func (d *Device) WriteRawPacket(packet []byte) error {
+	if len(packet) > MaxPacketBodySize {
+		return fmt.Errorf("packet exceeds max body size: %d > %d", len(packet), MaxPacketBodySize)
+	}
+
+	data := d.GetTempPacket()
+	defer d.PutTempPacket(data)
+	n := copy(data.Buffer[tunPacketOffset:], packet)
+	data.Packet = data.Buffer[tunPacketOffset : tunPacketOffset+n]
+
+	return d.WriteBufs([][]byte{data.Buf()})
 }
 
 // WriteBufs writes a prepared batch of TUN packets in a single tun.Write


### PR DESCRIPTION
Closes #17

On Android awldns was effectively dead: port 53 can't be bound without root, and there is no resolv.conf / OS DNS configurator to point the system at our resolver, so .awl names never resolved (queries went straight to the public upstream, bypassing the mapping).

Reserve a special in-subnet DNS IP and intercept DNS packets in the TUN read path, handling them in a userspace gVisor netstack stack. The Android host points VpnService.addDnsServer at that IP, so all device DNS arrives on it; the Tunnel diverts packets destined for it into a netstack bridge, where the existing awldns resolver serves on in-stack UDP/TCP :53 listeners. .awl is answered from the mapping, everything else is forwarded to the configured upstream — in VPN gateway client mode through the tunnel, so DNS does not leak.

The interceptor is enabled only on Android (runtime.GOOS); desktop keeps the local resolver + OS configurator path unchanged. dns.disableDNS is the feature's kill switch.

Main pieces:
- awldns/dnsbridge: gVisor netstack bridge that owns the DNS IP, pumps intercepted packets in and stack responses back out to the TUN, and exposes the in-stack :53 listeners.
- awldns: NewResolverFromListeners serves an already-open PacketConn / Listener via ActivateAndServe; server-ready flags moved to atomic.Bool.
- config: NetstackDNSIP, the reserved in-subnet DNS IP (broadcast−1 shifted past taken addresses), precomputed once in setDefaults and reserved on every platform; CheckIPUnique now also rejects the local node's own IP.
- service/tunnel: DNSPacketHandler + SetDNSHandler; a cheap dst==dnsIP filter in HandleReadPackets, ahead of the broadcast/gateway branches.
- vpn: Device.WriteRawPacket injects a ready-made IP packet into the TUN.
- application: initDNSAndroid wires the bridge + resolver and reports the DNS status to the UI/CLI; NetstackDNSServerIP is the host-facing liveness accessor.
- cmd/gomobile-lib: DnsServerIP() exports the address for the host.
- metrics: DNS intercept packet/drop counters.
- docs: README "Platform notes & known limitations" section.

The Android host side (Kotlin addDnsServer wiring, AAR rebuild) lives in the awl-flutter repo.