### PR TITLE
Upgrade Vietnamese Bootstrap to new server with 8 thread CPU

### DIFF
--- a/config/other.go
+++ b/config/other.go
@@ -46,9 +46,9 @@ func init() {
 		"/ip4/193.124.131.112/tcp/6150/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
 		"/ip4/193.124.131.112/udp/6150/quic-v1/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
 
-		// community relay server from pftmclub - location at Vietnam - Hosting Provided by VPSMMO.vn
-		"/ip4/103.77.242.85/tcp/6150/p2p/12D3KooWFdFV4ZcwMhNQuQnzNCp1K1aaQAsAnr8sXJnj7vehtCFW",
-		"/ip4/103.77.242.85/udp/6150/quic-v1/p2p/12D3KooWFdFV4ZcwMhNQuQnzNCp1K1aaQAsAnr8sXJnj7vehtCFW",
+		// community relay server from pftmclub - location at Vietnam - Hosting Provided by BNIX.vn
+		"/ip4/163.61.73.46/tcp/6150/p2p/12D3KooWFdFV4ZcwMhNQuQnzNCp1K1aaQAsAnr8sXJnj7vehtCFW",
+		"/ip4/163.61.73.46/udp/6150/quic-v1/p2p/12D3KooWFdFV4ZcwMhNQuQnzNCp1K1aaQAsAnr8sXJnj7vehtCFW",
 	} {
 		ma, err := multiaddr.NewMultiaddr(s)
 		if err != nil {

--- a/config/other.go
+++ b/config/other.go
@@ -47,8 +47,8 @@ func init() {
 		"/ip4/193.124.131.112/udp/6150/quic-v1/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
 
 		// community relay server from pftmclub - location at Vietnam - Hosting Provided by BNIX.vn
-		"/ip4/163.61.73.46/tcp/6150/p2p/12D3KooWFdFV4ZcwMhNQuQnzNCp1K1aaQAsAnr8sXJnj7vehtCFW",
-		"/ip4/163.61.73.46/udp/6150/quic-v1/p2p/12D3KooWFdFV4ZcwMhNQuQnzNCp1K1aaQAsAnr8sXJnj7vehtCFW",
+		"/ip4/180.93.113.217/tcp/6150/p2p/12D3KooWNgQ5xRFxwq17MF6JkZWZWuikdWrnQQ65NNrtFfXCbwcu",
+		"/ip4/180.93.113.217/udp/6150/quic-v1/p2p/12D3KooWNgQ5xRFxwq17MF6JkZWZWuikdWrnQQ65NNrtFfXCbwcu",
 	} {
 		ma, err := multiaddr.NewMultiaddr(s)
 		if err != nil {

--- a/config/other.go
+++ b/config/other.go
@@ -46,7 +46,7 @@ func init() {
 		"/ip4/193.124.131.112/tcp/6150/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
 		"/ip4/193.124.131.112/udp/6150/quic-v1/p2p/12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ",
 
-		// community relay server from pftmclub - location at Vietnam - Hosting Provided by BNIX.vn
+		// community relay server from pftmclub - location at Vietnam - Hosting Provided by VPSSIEUTOC.VN
 		"/ip4/180.93.113.217/tcp/6150/p2p/12D3KooWNgQ5xRFxwq17MF6JkZWZWuikdWrnQQ65NNrtFfXCbwcu",
 		"/ip4/180.93.113.217/udp/6150/quic-v1/p2p/12D3KooWNgQ5xRFxwq17MF6JkZWZWuikdWrnQQ65NNrtFfXCbwcu",
 	} {


### PR DESCRIPTION
Update Vietnamese bootstrap server to a new one with 8 core vCPU, 8 GB RAM and 100GB SSD.
Enjoy your new bootstrap

<img width="1361" height="1934" alt="image" src="https://github.com/user-attachments/assets/13e91e06-82e8-4051-8fc7-d71da5b72b9c" />
<img width="406" height="352" alt="image" src="https://github.com/user-attachments/assets/a314fec9-1d22-4894-827e-fb665c444999" />
