### PR TITLE
config: rework saving to be atomic and asynchronous

### DIFF
--- a/application.go
+++ b/application.go
@@ -3,6 +3,7 @@ package awl
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net"
@@ -276,8 +277,16 @@ func (a *Application) SetupLoggerAndConfig(appType config.AppType) *log.ZapEvent
 	a.logger = log.Logger("awl")
 	a.Conf = conf
 
-	if loadConfigErr != nil {
-		a.logger.Warnf("failed to read config file, creating new one: %v", loadConfigErr)
+	if errors.Is(loadConfigErr, fs.ErrNotExist) {
+		// First run: there is simply no config yet.
+		a.logger.Infof("no config file found, creating new one")
+	} else if loadConfigErr != nil {
+		// The file is there but unusable. We are about to run with a new
+		// identity and no known peers, and the first save will overwrite the
+		// old file, so this is data loss and must not read as a routine
+		// warning. LoadConfig has already copied a corrupted config aside.
+		a.logger.Errorf("failed to read existing config file, starting with a new one "+
+			"(previous identity and known peers will not be used): %v", loadConfigErr)
 	}
 	a.logger.Infof("Anywherelan %s (%s %s-%s)", config.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	a.logger.Infof("Initializing app in %s directory", conf.DataDir())
@@ -329,7 +338,7 @@ func (a *Application) Close() {
 			a.logger.Errorf("closing vpn: %v", err)
 		}
 	}
-	a.Conf.Save()
+	a.Conf.Close()
 }
 
 func (a *Application) makeP2pHostConfig() p2p.HostConfig {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/GrigoryKrasnochub/updaterini"
 	"github.com/ipfs/go-log/v2"
-	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 	"github.com/urfave/cli/v2"
 
 	"github.com/anywherelan/awl/api/apiclient"
@@ -518,7 +517,7 @@ func (a *Application) init() {
 				Action: func(c *cli.Context) error {
 					_, _ = fmt.Fprintf(a.cliapp.Writer, "current version: %s\n", config.Version)
 
-					conf, err := config.LoadConfig(a.appType, eventbus.NewBus())
+					conf, err := config.LoadConfigReadOnly(a.appType)
 					if err != nil {
 						return fmt.Errorf("update: read config: %v", err)
 					}
@@ -570,7 +569,7 @@ func (a *Application) initApiConnection(c *cli.Context) error {
 		return a.initApiFromAddr(apiAddr, username, password)
 	}
 
-	conf, errConfig := config.LoadConfig(a.appType, eventbus.NewBus())
+	conf, errConfig := config.LoadConfigReadOnly(a.appType)
 	if errConfig == nil {
 		if username == "" && password == "" {
 			username = conf.HttpBasicAuth.Username

--- a/cmd/awl-tray/go.mod
+++ b/cmd/awl-tray/go.mod
@@ -97,6 +97,8 @@ require (
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/moby/sys/atomicwriter v0.1.0 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/mr-tron/base58 v1.3.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect

--- a/cmd/awl-tray/go.sum
+++ b/cmd/awl-tray/go.sum
@@ -384,6 +384,10 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
+github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
+github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
+github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/cmd/awl-tray/main.go
+++ b/cmd/awl-tray/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gen2brain/beeep"
 	"github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/core/network"
-	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 
 	"github.com/anywherelan/awl"
 	"github.com/anywherelan/awl/awldns"
@@ -36,7 +35,7 @@ func getConfig() (*config.Config, error) {
 	if app != nil {
 		return app.Conf, nil
 	}
-	return config.LoadConfig(appType, eventbus.NewBus())
+	return config.LoadConfigReadOnly(appType)
 }
 
 func main() {

--- a/cmd/gomobile-lib/main.go
+++ b/cmd/gomobile-lib/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
 	"golang.zx2c4.com/wireguard/tun"
 
 	"github.com/anywherelan/awl"
@@ -39,9 +38,9 @@ func GetConfig() string {
 		panic("call to GetConfig before Setup")
 	}
 
-	conf, loadConfigErr := config.LoadConfig(appType, eventbus.NewBus())
+	conf, loadConfigErr := config.LoadConfigReadOnly(appType)
 	if loadConfigErr != nil {
-		conf = config.NewConfig(appType, eventbus.NewBus())
+		conf = config.NewConfigReadOnly(appType)
 	}
 
 	data := conf.Export()
@@ -186,9 +185,9 @@ func DnsServerIP() string {
 		panic("call to DnsServerIP before Setup")
 	}
 
-	conf, loadConfigErr := config.LoadConfig(appType, eventbus.NewBus())
+	conf, loadConfigErr := config.LoadConfigReadOnly(appType)
 	if loadConfigErr != nil {
-		conf = config.NewConfig(appType, eventbus.NewBus())
+		conf = config.NewConfigReadOnly(appType)
 	}
 	ip := conf.NetstackDNSIP()
 	if ip == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,17 @@ type (
 		// desktop for a future userspace-netstack path.
 		netstackDNSIP net.IP
 
+		// saveTrigger carries save requests to the writer goroutine. Capacity
+		// one, so a request that finds it full is simply dropped: a write is
+		// already queued and marshals at write time, which is what makes a
+		// burst of saves collapse into a single write of the newest state.
+		//
+		// nil on a config from NewConfigReadOnly/LoadConfigReadOnly, which has no writer.
+		saveTrigger chan struct{}
+		closeCh     chan struct{}
+		writerDone  chan struct{}
+		closeOnce   sync.Once
+
 		Version               string                 `json:"version"`
 		LoggerLevel           string                 `json:"loggerLevel"`
 		HttpListenAddress     string                 `json:"httpListenAddress"`
@@ -171,17 +182,22 @@ type (
 	}
 )
 
+// Save schedules a write of the config and returns immediately; the writer
+// goroutine performs it. It is safe to call with or without the config lock
+// held, because it touches no config state — only saveTrigger.
 func (c *Config) Save() {
-	c.RLock()
-	c.save()
-	c.RUnlock()
-}
+	if c.saveTrigger == nil {
+		// A read-only config has no writer. Reaching here means something
+		// mutated a snapshot and expected it to persist.
+		logger.DPanicf("Save called on a read-only config")
+		return
+	}
 
-// SaveLocked persists the config without taking the lock. The caller must
-// already hold c.Lock(). Use this when atomically batching mutations and
-// persistence under a single critical section.
-func (c *Config) SaveLocked() {
-	c.save()
+	select {
+	case c.saveTrigger <- struct{}{}:
+	default:
+		// a write is already queued and will pick up the newest state
+	}
 }
 
 func (c *Config) IsUniqPeerAlias(excludePeerID, alias string) bool {
@@ -251,12 +267,12 @@ func (c *Config) RemovePeer(peerID string) (KnownPeer, bool) {
 	knownPeer, exists := c.KnownPeers[peerID]
 	if exists {
 		delete(c.KnownPeers, peerID)
-		c.save()
+		c.Save()
 	}
 	c.Unlock()
 
 	if exists {
-		_ = c.emitter.Emit(awlevent.KnownPeerChanged{})
+		c.emitKnownPeerChanged()
 	}
 
 	return knownPeer, exists
@@ -265,21 +281,21 @@ func (c *Config) RemovePeer(peerID string) (KnownPeer, bool) {
 func (c *Config) UpsertPeer(peer KnownPeer) {
 	c.Lock()
 	c.KnownPeers[peer.PeerID] = peer
-	c.save()
+	c.Save()
 	c.Unlock()
 
-	_ = c.emitter.Emit(awlevent.KnownPeerChanged{})
+	c.emitKnownPeerChanged()
 }
 
 func (c *Config) UpsertPeerUnlocked(peer KnownPeer) {
 	c.KnownPeers[peer.PeerID] = peer
-	c.save()
+	c.Save()
 
-	_ = c.emitter.Emit(awlevent.KnownPeerChanged{})
+	c.emitKnownPeerChanged()
 }
 
 // UpdatePeerFields atomically applies mutate to the stored KnownPeer under the
-// write lock and persists the change. It returns false if the peer is unknown.
+// write lock. It returns false if the peer is unknown.
 //
 // mutate must only change the fields it owns and must NOT replace the struct
 // wholesale, so that fields updated concurrently by other callers are not
@@ -288,17 +304,30 @@ func (c *Config) UpsertPeerUnlocked(peer KnownPeer) {
 func (c *Config) UpdatePeerFields(peerID string, mutate func(*KnownPeer)) bool {
 	c.Lock()
 	knownPeer, ok := c.KnownPeers[peerID]
+	changed := false
 	if ok {
-		mutate(&knownPeer)
-		c.KnownPeers[peerID] = knownPeer
-		c.save()
+		updated := knownPeer
+		mutate(&updated)
+		c.KnownPeers[peerID] = updated
+
+		changed = peerChangedIgnoringLastSeen(knownPeer, updated)
+		if changed {
+			c.Save()
+		}
 	}
 	c.Unlock()
 
-	if ok {
-		_ = c.emitter.Emit(awlevent.KnownPeerChanged{})
+	if changed {
+		c.emitKnownPeerChanged()
 	}
 	return ok
+}
+
+// peerChangedIgnoringLastSeen reports whether anything except LastSeen differs.
+func peerChangedIgnoringLastSeen(before, after KnownPeer) bool {
+	before.LastSeen = time.Time{}
+	after.LastSeen = time.Time{}
+	return before != after
 }
 
 func (c *Config) UpdatePeerLastSeen(peerID string) {
@@ -323,7 +352,7 @@ func (c *Config) RemoveBlockedPeer(peerID string) {
 	_, exists := c.BlockedPeers[peerID]
 	if exists {
 		delete(c.BlockedPeers, peerID)
-		c.save()
+		c.Save()
 	}
 	c.Unlock()
 }
@@ -337,7 +366,7 @@ func (c *Config) UpsertBlockedPeer(peerID, displayName string) {
 	blockedPeer.PeerID = peerID
 	blockedPeer.DisplayName = displayName
 	c.BlockedPeers[peerID] = blockedPeer
-	c.save()
+	c.Save()
 	c.Unlock()
 }
 
@@ -348,7 +377,7 @@ func (c *Config) SetIdentity(key crypto.PrivKey, id peer.ID) {
 
 	c.P2pNode.Identity = identity
 	c.P2pNode.PeerID = id.String()
-	c.save()
+	c.Save()
 	c.Unlock()
 }
 
@@ -474,18 +503,75 @@ func (c *Config) Export() []byte {
 	return data
 }
 
-func (c *Config) save() {
+// Close stops the writer goroutine after a final flush and releases the event
+// emitter. It is idempotent and safe on a read-only config, which has neither.
+//
+// Callers of NewConfig and LoadConfig must call it, otherwise the writer
+// goroutine and the emitter's slot on the event bus outlive the config.
+func (c *Config) Close() {
+	c.closeOnce.Do(func() {
+		if c.saveTrigger != nil {
+			close(c.closeCh)
+			<-c.writerDone
+		}
+		if c.emitter != nil {
+			if err := c.emitter.Close(); err != nil {
+				logger.Errorf("Close config emitter: %v", err)
+			}
+		}
+	})
+}
+
+// startWriter launches the goroutine that owns writing this config to disk.
+// Called by the constructors that hand out a config someone will mutate; the
+// read-only ones skip it, which is what leaves saveTrigger nil.
+func (c *Config) startWriter() {
+	c.saveTrigger = make(chan struct{}, 1)
+	c.closeCh = make(chan struct{})
+	c.writerDone = make(chan struct{})
+
+	go c.writer()
+}
+
+func (c *Config) writer() {
+	defer close(c.writerDone)
+
+	for {
+		select {
+		case <-c.saveTrigger:
+			c.writeNow()
+		case <-c.closeCh:
+			// final flush
+			c.writeNow()
+			return
+		}
+	}
+}
+
+// writeNow is only ever called from the writer goroutine.
+func (c *Config) writeNow() {
+	c.RLock()
 	data, err := json.MarshalIndent(c, "", "  ")
+	c.RUnlock()
 	if err != nil {
+		// A marshal failure is a bug in the config structs, not an
+		// environmental problem, so it stays a DPanic.
 		logger.DPanicf("Marshal config: %v", err)
 		return
 	}
-	path := c.path()
-	err = os.WriteFile(path, data, filesPerm)
-	if err != nil {
+
+	if err = writeFileAtomic(c.path(), data); err != nil {
 		logger.DPanicf("Save config: %v", err)
 	}
-	ChownFileIfNeeded(path)
+}
+
+// emitKnownPeerChanged announces a change to the known peers.
+func (c *Config) emitKnownPeerChanged() {
+	// The emitter is nil on a read-only config.
+	if c.emitter == nil {
+		return
+	}
+	_ = c.emitter.Emit(awlevent.KnownPeerChanged{})
 }
 
 func (c *Config) path() string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,17 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_GetBootstrapPeers(t *testing.T) {
@@ -10,4 +20,203 @@ func TestConfig_GetBootstrapPeers(t *testing.T) {
 	if len(bootstrapPeers) != 5 {
 		t.Fatal()
 	}
+}
+
+func TestConfigSave(t *testing.T) {
+	conf, path := newTestConfig(t)
+
+	conf.Lock()
+	conf.P2pNode.Name = "first"
+	conf.Unlock()
+	conf.Save()
+
+	requireSaved(t, path, func(c *Config) bool {
+		return c.P2pNode.Name == "first"
+	})
+
+	conf.Lock()
+	conf.P2pNode.Name = "b"
+	conf.Unlock()
+	conf.Save()
+
+	requireSaved(t, path, func(c *Config) bool {
+		return c.P2pNode.Name == "b"
+	})
+
+	// make sure the staging file the atomic write goes through does not survive into the data dir.
+	entries, err := os.ReadDir(conf.dataDir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, AppConfigFilename, entries[0].Name())
+
+	// check permission. Windows has no unix modes: os.Stat reports 0666 for any
+	// writable file and 0444 for a read-only one, and Chmod only toggles the
+	// read-only attribute, so there is nothing to assert there.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(filesPerm), info.Mode().Perm())
+	}
+}
+
+func TestConfigSaveThenLoad(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(AppDataDirEnvKey, dir)
+
+	conf := &Config{dataDir: dir}
+	setDefaults(conf, eventbus.NewBus())
+	conf.startWriter()
+	conf.P2pNode.Name = "saved-node"
+	conf.KnownPeers["peer-1"] = KnownPeer{PeerID: "peer-1", Alias: "alias-1"}
+	conf.Save()
+	conf.Close()
+
+	loaded, err := LoadConfigReadOnly(AppTypeAwl)
+	require.NoError(t, err)
+	assert.Equal(t, "saved-node", loaded.P2pNode.Name)
+	assert.Equal(t, "alias-1", loaded.KnownPeers["peer-1"].Alias)
+}
+
+// TestConfigSaveCoalesces checks the property the capacity-one trigger buys:
+// a burst of saves neither blocks the caller nor turns into a write each, and
+// what lands on disk is the newest state rather than whichever snapshot won.
+func TestConfigSaveCoalesces(t *testing.T) {
+	conf, path := newTestConfig(t)
+
+	started := time.Now()
+	for i := range 200 {
+		conf.Lock()
+		conf.P2pNode.Name = fmt.Sprintf("node-%d", i)
+		conf.Unlock()
+		conf.Save()
+	}
+	elapsed := time.Since(started)
+
+	// A synchronous write is ~7ms, so 200 of them could not fit in this budget.
+	assert.Less(t, elapsed, 500*time.Millisecond, "Save appears to block on the write")
+
+	conf.RLock()
+	finalName := conf.P2pNode.Name
+	conf.RUnlock()
+	requireSaved(t, path, func(c *Config) bool { return c.P2pNode.Name == finalName })
+}
+
+func TestConfigCloseFlushesPendingSave(t *testing.T) {
+	dir := t.TempDir()
+	conf := &Config{dataDir: dir}
+	setDefaults(conf, eventbus.NewBus())
+	conf.startWriter()
+
+	conf.Lock()
+	conf.P2pNode.Name = "written-on-close"
+	conf.Unlock()
+
+	conf.Close()
+
+	// No Eventually: Close must not return before the flush is on disk.
+	data, err := os.ReadFile(filepath.Join(dir, AppConfigFilename))
+	require.NoError(t, err)
+	parsed := &Config{}
+	require.NoError(t, json.Unmarshal(data, parsed))
+	assert.Equal(t, "written-on-close", parsed.P2pNode.Name)
+
+	// check idempotent
+	assert.NotPanics(t, conf.Close, "Close must tolerate being called twice")
+}
+
+// TestConfigReadOnlyDoesNotWrite pins the point of the read-only constructors:
+// no writer goroutine, so nothing reaches disk and there is nothing to close.
+func TestConfigReadOnlyDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(AppDataDirEnvKey, dir)
+
+	conf := NewConfigReadOnly(AppTypeAwl)
+	require.Nil(t, conf.saveTrigger)
+	require.Nil(t, conf.emitter, "a read-only config must not hold an emitter")
+
+	// Save is a no-op rather than a panic: it DPanics, which aborts in dev mode
+	// to surface the misuse but only logs otherwise.
+	assert.NotPanics(t, conf.Save)
+	assert.NotPanics(t, conf.Close, "Close on a read-only config must be a no-op")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+// TestLoadConfigCorrupted covers the fallback path: callers replace an
+// unloadable config with a fresh one and overwrite the file, so the original
+// bytes must be preserved first or the node's identity is lost for good.
+func TestLoadConfigCorrupted(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(AppDataDirEnvKey, dir)
+	configPath := filepath.Join(dir, AppConfigFilename)
+
+	// Truncated JSON, the shape an interrupted non-atomic write produces.
+	corrupted := []byte(`{"p2pNode": {"name": "my-node", "identi`)
+	require.NoError(t, os.WriteFile(configPath, corrupted, filesPerm))
+
+	_, err := LoadConfigReadOnly(AppTypeAwl)
+	require.Error(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var backups []string
+	for _, entry := range entries {
+		if entry.Name() != AppConfigFilename {
+			backups = append(backups, entry.Name())
+		}
+	}
+	require.Len(t, backups, 1, "expected exactly one backup, got %v", entries)
+
+	data, err := os.ReadFile(filepath.Join(dir, backups[0]))
+	require.NoError(t, err)
+	assert.Equal(t, corrupted, data)
+}
+
+func TestLoadConfigMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(AppDataDirEnvKey, dir)
+
+	_, err := LoadConfigReadOnly(AppTypeAwl)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	// A first run is not corruption: nothing should be backed up.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func newTestConfig(t *testing.T) (*Config, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	conf := &Config{dataDir: dir}
+	setDefaults(conf, eventbus.NewBus())
+	conf.startWriter()
+	t.Cleanup(conf.Close)
+
+	return conf, filepath.Join(dir, AppConfigFilename)
+}
+
+// requireSaved waits for the writer goroutine to put a config on disk that
+// satisfies check. Saving is asynchronous, so tests cannot read the file
+// straight after Save.
+func requireSaved(t *testing.T, path string, check func(*Config) bool) {
+	t.Helper()
+
+	var last []byte
+	require.Eventually(t, func() bool {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return false
+		}
+		last = data
+		parsed := &Config{}
+		if err := json.Unmarshal(data, parsed); err != nil {
+			return false
+		}
+		return check(parsed)
+	}, 3*time.Second, 10*time.Millisecond, "config on disk never matched; last read: %s", last)
 }

--- a/config/other.go
+++ b/config/other.go
@@ -8,9 +8,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"time"
 
 	"github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p/p2p/host/eventbus"
+	"github.com/moby/sys/atomicwriter"
 	"github.com/multiformats/go-multiaddr"
 
 	"github.com/anywherelan/awl/awldns"
@@ -99,28 +101,80 @@ func CalcAppDataDir() string {
 	return userDataDir
 }
 
+// NewConfig returns a config with defaults applied. The caller must call Close.
+// Use NewConfigReadOnly when the config is only going to be read.
 func NewConfig(appType AppType, bus awlevent.Bus) *Config {
 	conf := &Config{appType: appType}
 	setDefaults(conf, bus)
+	conf.startWriter()
 	return conf
 }
 
+// NewConfigReadOnly returns a defaults-only config for inspection.
+// Save on it is a no-op that DPanics in dev mode.
+func NewConfigReadOnly(appType AppType) *Config {
+	conf := &Config{appType: appType}
+	setDefaults(conf, nil)
+	return conf
+}
+
+// LoadConfig reads the config from disk. The caller must call Close.
+// Use LoadConfigReadOnly when the config is only going to be read.
+// A missing file is reported as fs.ErrNotExist, which callers use to tell an
+// ordinary first run apart from a real failure.
 func LoadConfig(appType AppType, bus awlevent.Bus) (*Config, error) {
+	conf, err := loadConfig(appType, bus)
+	if err != nil {
+		return nil, err
+	}
+	conf.startWriter()
+	return conf, nil
+}
+
+// LoadConfigReadOnly reads the config from disk for inspection.
+// Save on it is a no-op that DPanics in dev mode.
+func LoadConfigReadOnly(appType AppType) (*Config, error) {
+	return loadConfig(appType, nil)
+}
+
+func loadConfig(appType AppType, bus awlevent.Bus) (*Config, error) {
 	dataDir := CalcAppDataDir()
 	configPath := filepath.Join(dataDir, AppConfigFilename)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
+		// Includes the ordinary first-run case (no config yet). Callers tell
+		// it apart from a real failure with errors.Is(err, fs.ErrNotExist).
 		return nil, err
 	}
 	// TODO: config migration
 	conf := &Config{appType: appType}
 	err = json.Unmarshal(data, conf)
 	if err != nil {
+		// The file exists but does not parse. Callers fall back to a default
+		// config, which will overwrite this file with a new identity, so
+		// preserve the bytes first — see backupCorruptedFile.
+		backupPath, backupErr := backupCorruptedFile(configPath, data)
+		if backupErr != nil {
+			logger.Errorf("config '%s' is corrupted and could not be backed up: %v (parse error: %v)",
+				configPath, backupErr, err)
+		} else {
+			logger.Errorf("config '%s' is corrupted, a copy was saved to '%s': %v", configPath, backupPath, err)
+		}
 		return nil, err
 	}
 	conf.dataDir = dataDir
 	setDefaults(conf, bus)
 	return conf, nil
+}
+
+// backupCorruptedFile saves data (the unparseable contents just read from
+// path) next to it under a timestamped name, and returns that name.
+func backupCorruptedFile(path string, data []byte) (string, error) {
+	backupPath := fmt.Sprintf("%s.corrupt-%s", path, time.Now().UTC().Format("20060102-150405"))
+	if err := writeFileAtomic(backupPath, data); err != nil {
+		return "", err
+	}
+	return backupPath, nil
 }
 
 func ImportConfig(data []byte, directory string) error {
@@ -131,7 +185,7 @@ func ImportConfig(data []byte, directory string) error {
 	}
 
 	path := filepath.Join(directory, AppConfigFilename)
-	err = os.WriteFile(path, data, filesPerm)
+	err = writeFileAtomic(path, data)
 	if err != nil {
 		return fmt.Errorf("save file: %v", err)
 	}
@@ -140,6 +194,9 @@ func ImportConfig(data []byte, directory string) error {
 	return nil
 }
 
+// setDefaults fills in unset fields and wires up the event emitter. A nil bus
+// marks a read-only config, which is left without one; see NewConfigReadOnly.
+//
 //nolint:gocyclo
 func setDefaults(conf *Config, bus awlevent.Bus) {
 	isEmptyConfig := conf.Version == ""
@@ -244,11 +301,14 @@ func setDefaults(conf *Config, bus awlevent.Bus) {
 	// }
 	// ChownFileIfNeeded(peerstoreDir)
 
-	emitter, err := bus.Emitter(new(awlevent.KnownPeerChanged), eventbus.Stateful)
-	if err != nil {
-		panic(err)
+	// A nil bus marks a read-only config: nobody can subscribe to it
+	if bus != nil {
+		emitter, err := bus.Emitter(new(awlevent.KnownPeerChanged), eventbus.Stateful)
+		if err != nil {
+			panic(err)
+		}
+		conf.emitter = emitter
 	}
-	conf.emitter = emitter
 
 	if u := conf.Update.UpdateServerURL; u == "" || u == "http://example/example.json" {
 		conf.Update.UpdateServerURL = "https://build.anywherelan.com/repository/releases.json"
@@ -273,4 +333,16 @@ func ChownFileIfNeeded(path string) {
 	if err != nil {
 		logger.Errorf("Chown file '%s': %v", path, err)
 	}
+}
+
+// writeFileAtomic writes data to path so that a reader sees either the
+// complete old contents or the complete new contents, never a truncated mix.
+// atomicwriter stages the data in a temp file next to the target, fsyncs and
+// chmods it, then renames it over the target.
+func writeFileAtomic(path string, data []byte) error {
+	if err := atomicwriter.WriteFile(path, data, filesPerm); err != nil {
+		return err
+	}
+	ChownFileIfNeeded(path)
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/marcopolo/simnet v0.0.7
 	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/miekg/dns v1.1.72
+	github.com/moby/sys/atomicwriter v0.1.0
 	github.com/mr-tron/base58 v1.3.0
 	github.com/multiformats/go-multiaddr v0.16.1
 	github.com/multiformats/go-multistream v0.6.1
@@ -100,6 +101,7 @@ require (
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,10 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
+github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
+github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
+github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/service/tunnel.go
+++ b/service/tunnel.go
@@ -582,7 +582,7 @@ func (t *Tunnel) SetVPNGatewayServerEnabled(enabled bool) {
 	t.vpnGatewayServerEnabled = enabled
 	t.conf.Lock()
 	t.conf.VPNGateway.ServerEnabled = enabled
-	t.conf.SaveLocked()
+	t.conf.Save()
 	t.conf.Unlock()
 	t.peersLock.Unlock()
 }
@@ -622,7 +622,7 @@ func (t *Tunnel) SetVPNGatewayPeer(gatewayPeerID peer.ID) error {
 	t.conf.Lock()
 	t.conf.VPNGateway.ClientEnabled = true
 	t.conf.VPNGateway.GatewayPeerID = gatewayPeerID.String()
-	t.conf.SaveLocked()
+	t.conf.Save()
 	t.conf.Unlock()
 
 	// Seed connectivity from the current state and emit it, so the UI gets an
@@ -650,7 +650,7 @@ func (t *Tunnel) ClearVPNGatewayPeer() {
 	t.conf.Lock()
 	t.conf.VPNGateway.ClientEnabled = false
 	t.conf.VPNGateway.GatewayPeerID = ""
-	t.conf.SaveLocked()
+	t.conf.Save()
 	t.conf.Unlock()
 }
 

--- a/service/vpn_gateway.go
+++ b/service/vpn_gateway.go
@@ -196,7 +196,7 @@ func (g *VPNGateway) DisableClient() {
 	g.conf.Lock()
 	g.conf.VPNGateway.ClientEnabled = false
 	g.conf.VPNGateway.GatewayPeerID = ""
-	g.conf.SaveLocked()
+	g.conf.Save()
 	g.conf.Unlock()
 }
 
@@ -218,7 +218,7 @@ func (g *VPNGateway) SetServerEnabled(enabled bool) error {
 		} else {
 			g.conf.Lock()
 			g.conf.VPNGateway.ServerEnabled = true
-			g.conf.SaveLocked()
+			g.conf.Save()
 			g.conf.Unlock()
 		}
 		return nil
@@ -229,7 +229,7 @@ func (g *VPNGateway) SetServerEnabled(enabled bool) error {
 	} else {
 		g.conf.Lock()
 		g.conf.VPNGateway.ServerEnabled = false
-		g.conf.SaveLocked()
+		g.conf.Save()
 		g.conf.Unlock()
 	}
 	g.teardownServer()

--- a/test_suite_test.go
+++ b/test_suite_test.go
@@ -185,7 +185,7 @@ func (ts *TestSuite) buildTestPeer(disableLogging bool, listenAddrs []multiaddr.
 		tempConf.LoggerLevel = "fatal"
 		log.SetAllLoggers(log.LevelFatal)
 	}
-	tempConf.Save()
+	tempConf.Close()
 
 	app := New()
 	app.AllowEmptyBootstrapPeers = ts.isSimnet


### PR DESCRIPTION
Config.save used os.WriteFile, which truncates the target before writing: killing awl in that window destroyed the config, losing the node's private key and known peers irrecoverably, and readers in other processes (awl-tray, CLI subcommands) could see the truncated file. A config that failed to parse was then quietly discarded — callers fall back to a fresh default that overwrites the same path with a new identity on the next start.

Making the write atomic turns a save into an fsync, ~7ms instead of ~0.1ms, and it happened inline under the caller's lock. Tunnel's VPN gateway setters save while holding peersLock, which HandleReadPackets needs for every batch read from the TUN, so the packet path stalled for the duration of the write.

- Writes go through moby/sys/atomicwriter: staged next to the target, fsynced, renamed over it.
- An unparseable config is copied to config_awl.json.corrupt-<ts> before the fallback, which is now logged as an error rather than a warning indistinguishable from a first run.
- Save hands the request to a single writer goroutine over a capacity-one channel and returns. The writer marshals at write time, so a burst collapses into one write of the newest state.
- Config.Close flushes, stops the writer and closes the emitter, which was never released before — a leak on every gomobile restart.
- NewConfigReadOnly / LoadConfigReadOnly for configs that are only read (CLI, tray without a running server, gomobile GetConfig and DnsServerIP): no writer, no emitter, nothing to close.
- UpdatePeerFields saves and emits only when something other than LastSeen changed. Status exchanges are the dominant caller and usually change nothing else.