### PR TITLE
invites: add invite links for automatic peer acceptance

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -150,6 +150,9 @@ func (h *Handler) setupRouter(address string) (*echo.Echo, error) {
 	e.POST(RemovePeerSettingsPath, h.RemovePeer)
 	e.GET(GetAuthRequestsPath, h.GetAuthRequests)
 	e.GET(GetBlockedPeersPath, h.GetBlockedPeers)
+	e.POST(CreateInvitePath, h.CreateInvite)
+	e.GET(GetInvitesPath, h.GetInvites)
+	e.POST(RevokeInvitePath, h.RevokeInvite)
 
 	// Settings
 	e.GET(GetMyPeerInfoPath, h.GetMyPeerInfo)

--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,7 @@ import (
 	http_pprof "net/http/pprof"
 	"runtime/pprof"
 	"strings"
+	"unicode"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/ipfs/go-log/v2"
@@ -111,6 +112,10 @@ func (h *Handler) setupRouter(address string) (*echo.Echo, error) {
 
 	val := validator.New()
 	err = val.RegisterValidation("trimmed_str_not_empty", validateTrimmedStringNotEmpty, false)
+	if err != nil {
+		return nil, err
+	}
+	err = val.RegisterValidation("no_control_chars", validateNoControlChars, false)
 	if err != nil {
 		return nil, err
 	}
@@ -265,4 +270,8 @@ func validateTrimmedStringNotEmpty(fl validator.FieldLevel) bool {
 	str := fl.Field().String()
 	str = strings.TrimSpace(str)
 	return len(str) > 0
+}
+
+func validateNoControlChars(fl validator.FieldLevel) bool {
+	return !strings.ContainsFunc(fl.Field().String(), unicode.IsControl)
 }

--- a/api/apiclient/client.go
+++ b/api/apiclient/client.go
@@ -116,6 +116,29 @@ func (c *Client) AuthRequests() ([]entity.AuthRequest, error) {
 	return authRequests, nil
 }
 
+func (c *Client) CreateInvite(request entity.CreateInviteRequest) (*entity.InviteResponse, error) {
+	invite := new(entity.InviteResponse)
+	err := c.sendPostRequest(api.CreateInvitePath, request, invite)
+	if err != nil {
+		return nil, err
+	}
+	return invite, nil
+}
+
+func (c *Client) Invites() ([]entity.InviteResponse, error) {
+	invites := make([]entity.InviteResponse, 0)
+	err := c.sendGetRequest(api.GetInvitesPath, &invites)
+	if err != nil {
+		return nil, err
+	}
+	return invites, nil
+}
+
+func (c *Client) RevokeInvite(id string) error {
+	request := entity.RevokeInviteRequest{ID: id}
+	return c.sendPostRequest(api.RevokeInvitePath, request, nil)
+}
+
 func (c *Client) BlockedPeers() ([]config.BlockedPeer, error) {
 	blocked := make([]config.BlockedPeer, 0)
 	err := c.sendGetRequest(api.GetBlockedPeersPath, &blocked)

--- a/api/apiclient/client.go
+++ b/api/apiclient/client.go
@@ -99,22 +99,11 @@ func (c *Client) UpdateProxySettings(usingPeerID string) error {
 	return c.sendPostRequest(api.UpdateProxySettingsPath, request, nil)
 }
 
-func (c *Client) SendFriendRequest(peerID, alias string, ipAddr string) error {
-	request := entity.FriendRequest{
-		PeerID: peerID,
-		Alias:  alias,
-		IPAddr: ipAddr,
-	}
+func (c *Client) SendFriendRequest(request entity.FriendRequest) error {
 	return c.sendPostRequest(api.SendFriendRequestPath, request, nil)
 }
 
-func (c *Client) ReplyFriendRequest(peerID, alias string, decline bool, ipAddr string) error {
-	request := entity.FriendRequestReply{
-		PeerID:  peerID,
-		Alias:   alias,
-		Decline: decline,
-		IPAddr:  ipAddr,
-	}
+func (c *Client) ReplyFriendRequest(request entity.FriendRequestReply) error {
 	return c.sendPostRequest(api.AcceptPeerInvitationPath, request, nil)
 }
 

--- a/api/const.go
+++ b/api/const.go
@@ -15,6 +15,11 @@ const (
 	AcceptPeerInvitationPath = V0Prefix + "peers/accept_peer"
 	GetAuthRequestsPath      = V0Prefix + "peers/auth_requests"
 
+	// Invite links
+	CreateInvitePath = V0Prefix + "peers/invites/create"
+	GetInvitesPath   = V0Prefix + "peers/invites/list"
+	RevokeInvitePath = V0Prefix + "peers/invites/revoke"
+
 	// Settings
 	GetMyPeerInfoPath        = V0Prefix + "settings/peer_info"
 	UpdateMyInfoPath         = V0Prefix + "settings/update"

--- a/api/invites.go
+++ b/api/invites.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/anywherelan/awl/config"
+	"github.com/anywherelan/awl/entity"
+)
+
+const defaultInviteMaxUses = 1
+
+// @Tags		Peers
+// @Summary	Create an invite link
+// @Accept		json
+// @Produce	json
+// @Param		body	body		entity.CreateInviteRequest	true	"Params"
+// @Success	200		{object}	entity.InviteResponse
+// @Failure	400		{object}	api.Error
+// @Failure	500		{object}	api.Error
+// @Router		/peers/invites/create [POST]
+func (h *Handler) CreateInvite(c echo.Context) (err error) {
+	req := entity.CreateInviteRequest{}
+	err = c.Bind(&req)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorMessage(err.Error()))
+	}
+	if err = c.Validate(req); err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorMessage(err.Error()))
+	}
+
+	if req.MaxUses == 0 {
+		req.MaxUses = defaultInviteMaxUses
+	}
+	req.Alias = strings.TrimSpace(req.Alias)
+	// One alias cannot name several peers, so it only makes sense for a
+	// single-use link. Uniqueness itself is not checked here: the peer list will
+	// have moved on by the time the link is redeemed, and a collision is
+	// resolved then (GenUniqPeerAlias), so checking now would only produce
+	// false rejections.
+	if req.Alias != "" && req.MaxUses != 1 {
+		return c.JSON(http.StatusBadRequest,
+			ErrorMessage("alias can only be set for a single-use invite"))
+	}
+
+	var expiresAt time.Time
+	if req.ExpiresInSeconds > 0 {
+		expiresAt = time.Now().Add(time.Duration(req.ExpiresInSeconds) * time.Second)
+	}
+
+	invite, err := h.conf.CreateInvite(config.CreateInviteParams{
+		Label:                req.Label,
+		Alias:                req.Alias,
+		AllowUsingAsExitNode: req.AllowUsingAsExitNode,
+		MaxUses:              req.MaxUses,
+		ExpiresAt:            expiresAt,
+	})
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorMessage(err.Error()))
+	}
+
+	return c.JSON(http.StatusOK, h.inviteResponse(invite))
+}
+
+// @Tags		Peers
+// @Summary	Get invite links
+// @Accept		json
+// @Produce	json
+// @Success	200	{array}	entity.InviteResponse
+// @Router		/peers/invites/list [GET]
+func (h *Handler) GetInvites(c echo.Context) (err error) {
+	invites := h.conf.ListInvites()
+
+	result := make([]entity.InviteResponse, 0, len(invites))
+	for _, invite := range invites {
+		result = append(result, h.inviteResponse(invite))
+	}
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// @Tags		Peers
+// @Summary	Revoke an invite link
+// @Description Stops new connections through the link; peers already added stay.
+// @Accept		json
+// @Produce	json
+// @Param		body	body	entity.RevokeInviteRequest	true	"Params"
+// @Success	200		"OK"
+// @Failure	400		{object}	api.Error
+// @Failure	404		{object}	api.Error
+// @Router		/peers/invites/revoke [POST]
+func (h *Handler) RevokeInvite(c echo.Context) (err error) {
+	req := entity.RevokeInviteRequest{}
+	err = c.Bind(&req)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorMessage(err.Error()))
+	}
+	if err = c.Validate(req); err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorMessage(err.Error()))
+	}
+
+	if !h.conf.RevokeInvite(req.ID) {
+		return c.JSON(http.StatusNotFound, ErrorMessage("invite not found"))
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+// inviteResponse renders an invite for the API, building the link from our
+// current peer ID and node name.
+func (h *Handler) inviteResponse(invite config.Invite) entity.InviteResponse {
+	h.conf.RLock()
+	peerID := h.conf.P2pNode.PeerID
+	nodeName := h.conf.P2pNode.Name
+	h.conf.RUnlock()
+
+	return entity.InviteResponse{
+		ID:                   invite.ID,
+		Label:                invite.Label,
+		Link:                 entity.BuildInviteLink(peerID, invite.Token, nodeName),
+		Alias:                invite.Alias,
+		AllowUsingAsExitNode: invite.WeAllowUsingAsExitNode,
+		MaxUses:              invite.MaxUses,
+		UsedCount:            invite.UsedCount,
+		ExpiresAt:            invite.ExpiresAt,
+		CreatedAt:            invite.CreatedAt,
+		Revoked:              invite.Revoked,
+		Status:               inviteStatus(invite),
+	}
+}
+
+func inviteStatus(invite config.Invite) string {
+	switch {
+	case invite.Revoked:
+		return entity.InviteStatusRevoked
+	case invite.IsExpired(time.Now()):
+		return entity.InviteStatusExpired
+	case invite.IsUsedUp():
+		return entity.InviteStatusUsedUp
+	}
+	return entity.InviteStatusActive
+}

--- a/api/peers.go
+++ b/api/peers.go
@@ -57,6 +57,7 @@ func (h *Handler) getKnownPeers() []entity.KnownPeersResponse {
 			WeAllowUsingAsExitNode:        knownPeer.WeAllowUsingAsExitNode,
 			AllowedUsingAsExitNode:        knownPeer.AllowedUsingAsExitNode,
 			RemoteVPNGatewayServerEnabled: knownPeer.RemoteVPNGatewayServerEnabled,
+			InviteID:                      knownPeer.InviteID,
 			LastSeen:                      knownPeer.LastSeen,
 			Connections:                   h.p2p.PeerConnectionsInfo(id),
 			NetworkStats:                  netStats,
@@ -188,6 +189,7 @@ func (h *Handler) SendFriendRequest(c echo.Context) (err error) {
 		Alias:                req.Alias,
 		IPAddr:               req.IPAddr,
 		AllowUsingAsExitNode: req.AllowUsingAsExitNode,
+		PendingInviteToken:   req.Token,
 	})
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorMessage(err.Error()))

--- a/api/peers.go
+++ b/api/peers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/anywherelan/awl/awldns"
 	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/entity"
+	"github.com/anywherelan/awl/service"
 )
 
 const ErrorPeerAliasIsNotUniq = "peer name is not unique"
@@ -182,7 +183,12 @@ func (h *Handler) SendFriendRequest(c echo.Context) (err error) {
 			ErrorMessage("You can't add yourself"))
 	}
 
-	err = h.authStatus.AddPeer(h.ctx, peerId, "", req.Alias, false, req.IPAddr)
+	err = h.authStatus.AddPeer(h.ctx, service.AddPeerParams{
+		PeerID:               peerId,
+		Alias:                req.Alias,
+		IPAddr:               req.IPAddr,
+		AllowUsingAsExitNode: req.AllowUsingAsExitNode,
+	})
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorMessage(err.Error()))
 	}
@@ -230,7 +236,14 @@ func (h *Handler) AcceptFriend(c echo.Context) (err error) {
 		return c.NoContent(http.StatusOK)
 	}
 
-	err = h.authStatus.AddPeer(h.ctx, peerId, auth.Name, req.Alias, true, req.IPAddr)
+	err = h.authStatus.AddPeer(h.ctx, service.AddPeerParams{
+		PeerID:               peerId,
+		Name:                 auth.Name,
+		Alias:                req.Alias,
+		Confirmed:            true,
+		IPAddr:               req.IPAddr,
+		AllowUsingAsExitNode: req.AllowUsingAsExitNode,
+	})
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorMessage(err.Error()))
 	}

--- a/api_handlers_test.go
+++ b/api_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/anywherelan/awl/api"
 	"github.com/anywherelan/awl/config"
@@ -127,6 +128,89 @@ func TestAcceptFriend_ErrorCases(t *testing.T) {
 		err := peer1.api.ReplyFriendRequest(entity.FriendRequestReply{PeerID: "bad-peer-id", Alias: "alias"})
 		ts.Error(err)
 		ts.ErrorContains(err, "Invalid hex-encoded multihash")
+	})
+}
+
+// TestInvitesAPI covers the invite link lifecycle through the API alone:
+// creating a link, seeing it in the list and revoking it. Redeeming one takes
+// two nodes and lives in application_test.go (TestAddPeerViaInviteLink and
+// around it).
+func TestInvitesAPI(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	peer1 := ts.NewTestPeer(false)
+	err := peer1.api.UpdateMySettings("alice")
+	ts.NoError(err)
+
+	invites, err := peer1.api.Invites()
+	ts.NoError(err)
+	ts.Len(invites, 0)
+
+	created, err := peer1.api.CreateInvite(entity.CreateInviteRequest{
+		Label:                "my laptop",
+		Alias:                "laptop",
+		AllowUsingAsExitNode: true,
+		ExpiresInSeconds:     int64((24 * time.Hour).Seconds()),
+	})
+	ts.NoError(err)
+	ts.Equal(1, created.MaxUses, "MaxUses defaults to single-use")
+	ts.Equal(0, created.UsedCount)
+	ts.Equal(entity.InviteStatusActive, created.Status)
+	ts.True(created.AllowUsingAsExitNode)
+	ts.False(created.Revoked)
+	ts.WithinDuration(time.Now().Add(24*time.Hour), created.ExpiresAt, time.Minute)
+
+	link, err := entity.ParseInviteLink(created.Link)
+	ts.NoError(err)
+	ts.Equal(peer1.PeerID(), link.PeerID)
+	ts.Equal("alice", link.Name)
+	ts.NotEmpty(link.Token)
+
+	// The token only ever leaves through the link, never as a field of its own.
+	withoutLink := *created
+	withoutLink.Link = ""
+	body, err := json.Marshal(withoutLink)
+	ts.NoError(err)
+	ts.NotContains(string(body), link.Token)
+
+	invites, err = peer1.api.Invites()
+	ts.NoError(err)
+	ts.Len(invites, 1)
+	ts.Equal(*created, invites[0])
+
+	err = peer1.api.RevokeInvite(created.ID)
+	ts.NoError(err)
+
+	invites, err = peer1.api.Invites()
+	ts.NoError(err)
+	ts.Len(invites, 1)
+	ts.True(invites[0].Revoked, "revoked invites stay in the list as history")
+	ts.Equal(entity.InviteStatusRevoked, invites[0].Status)
+
+	err = peer1.api.RevokeInvite("00000000")
+	ts.Error(err)
+	ts.ErrorContains(err, "invite not found")
+}
+
+func TestCreateInvite_ErrorCases(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	peer1 := ts.NewTestPeer(false)
+
+	t.Run("AliasWithMultiUse", func(t *testing.T) {
+		_, err := peer1.api.CreateInvite(entity.CreateInviteRequest{MaxUses: 5, Alias: "laptop"})
+		ts.Error(err)
+		ts.ErrorContains(err, "alias can only be set for a single-use invite")
+	})
+
+	t.Run("TooManyUses", func(t *testing.T) {
+		_, err := peer1.api.CreateInvite(entity.CreateInviteRequest{MaxUses: 1000})
+		ts.Error(err)
+	})
+
+	t.Run("NegativeExpiry", func(t *testing.T) {
+		_, err := peer1.api.CreateInvite(entity.CreateInviteRequest{ExpiresInSeconds: -1})
+		ts.Error(err)
 	})
 }
 

--- a/api_handlers_test.go
+++ b/api_handlers_test.go
@@ -93,13 +93,13 @@ func TestSendFriendRequest_ErrorCases(t *testing.T) {
 	peer1 := ts.NewTestPeer(false)
 
 	t.Run("SelfAdd", func(t *testing.T) {
-		err := peer1.api.SendFriendRequest(peer1.PeerID(), "self", "")
+		err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer1.PeerID(), Alias: "self"})
 		ts.Error(err)
 		ts.ErrorContains(err, "You can't add yourself")
 	})
 
 	t.Run("InvalidPeerID", func(t *testing.T) {
-		err := peer1.api.SendFriendRequest("not-a-valid-peer-id", "alias", "")
+		err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: "not-a-valid-peer-id", Alias: "alias"})
 		ts.Error(err)
 		ts.ErrorContains(err, "Invalid hex-encoded multihash")
 	})
@@ -112,19 +112,19 @@ func TestAcceptFriend_ErrorCases(t *testing.T) {
 	peer2 := ts.NewTestPeer(false)
 
 	t.Run("NoPendingRequest", func(t *testing.T) {
-		err := peer1.api.ReplyFriendRequest(peer2.PeerID(), "peer_2", false, "")
+		err := peer1.api.ReplyFriendRequest(entity.FriendRequestReply{PeerID: peer2.PeerID(), Alias: "peer_2"})
 		ts.Error(err)
 		ts.ErrorContains(err, "Peer did not send you friend request")
 	})
 
 	t.Run("SelfAdd", func(t *testing.T) {
-		err := peer1.api.ReplyFriendRequest(peer1.PeerID(), "self", false, "")
+		err := peer1.api.ReplyFriendRequest(entity.FriendRequestReply{PeerID: peer1.PeerID(), Alias: "self"})
 		ts.Error(err)
 		ts.ErrorContains(err, "You can't add yourself")
 	})
 
 	t.Run("InvalidPeerID", func(t *testing.T) {
-		err := peer1.api.ReplyFriendRequest("bad-peer-id", "alias", false, "")
+		err := peer1.api.ReplyFriendRequest(entity.FriendRequestReply{PeerID: "bad-peer-id", Alias: "alias"})
 		ts.Error(err)
 		ts.ErrorContains(err, "Invalid hex-encoded multihash")
 	})

--- a/application_test.go
+++ b/application_test.go
@@ -66,7 +66,7 @@ func TestRemovePeer(t *testing.T) {
 	ts.Len(peer2.app.AuthStatus.GetIngoingAuthRequests(), 0)
 
 	// Add peer2 from peer1 - should succeed
-	err = peer1.api.SendFriendRequest(peer2.PeerID(), "peer_2", "")
+	err = peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer2.PeerID(), Alias: "peer_2"})
 	ts.NoError(err)
 	time.Sleep(500 * time.Millisecond)
 
@@ -103,7 +103,7 @@ func TestDeclinePeerFriendRequest(t *testing.T) {
 	peer2 := ts.NewTestPeer(false)
 	ts.ensurePeersAvailableInDHT(peer1, peer2)
 
-	err := peer1.api.SendFriendRequest(peer2.PeerID(), "peer_2", "")
+	err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer2.PeerID(), Alias: "peer_2"})
 	ts.NoError(err)
 
 	var authRequests []entity.AuthRequest
@@ -112,7 +112,7 @@ func TestDeclinePeerFriendRequest(t *testing.T) {
 		ts.NoError(err)
 		return len(authRequests) == 1
 	}, 15*time.Second, 50*time.Millisecond)
-	err = peer2.api.ReplyFriendRequest(authRequests[0].PeerID, "peer_1", true, "")
+	err = peer2.api.ReplyFriendRequest(entity.FriendRequestReply{PeerID: authRequests[0].PeerID, Alias: "peer_1", Decline: true})
 	ts.NoError(err)
 
 	time.Sleep(500 * time.Millisecond)
@@ -142,7 +142,7 @@ func TestAutoAcceptFriendRequest(t *testing.T) {
 	peer2.app.Conf.P2pNode.AutoAcceptAuthRequests = true
 	peer2.app.Conf.Unlock()
 
-	err := peer1.api.SendFriendRequest(peer2.PeerID(), "peer_2", "")
+	err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer2.PeerID(), Alias: "peer_2"})
 	ts.NoError(err)
 
 	ts.Eventually(func() bool {
@@ -174,7 +174,7 @@ func TestFriendRequestWithCustomIP(t *testing.T) {
 
 	t.Run("InviteWithCustomIP", func(t *testing.T) {
 		customIP := "10.66.0.222"
-		err := peer1.api.SendFriendRequest(peer2.PeerID(), "peer_2", customIP)
+		err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer2.PeerID(), Alias: "peer_2", IPAddr: customIP})
 		ts.NoError(err)
 
 		// Check immediate state on peer1
@@ -184,7 +184,7 @@ func TestFriendRequestWithCustomIP(t *testing.T) {
 	})
 
 	t.Run("RespondWithCustomIP", func(t *testing.T) {
-		err := peer3.api.SendFriendRequest(peer1.PeerID(), "peer_1", "")
+		err := peer3.api.SendFriendRequest(entity.FriendRequest{PeerID: peer1.PeerID(), Alias: "peer_1"})
 		ts.NoError(err)
 
 		var authRequests []entity.AuthRequest
@@ -195,7 +195,7 @@ func TestFriendRequestWithCustomIP(t *testing.T) {
 		}, 15*time.Second, 50*time.Millisecond)
 
 		customIP := "10.66.0.223"
-		err = peer1.api.ReplyFriendRequest(authRequests[0].PeerID, "peer_3", false, customIP)
+		err = peer1.api.ReplyFriendRequest(entity.FriendRequestReply{PeerID: authRequests[0].PeerID, Alias: "peer_3", IPAddr: customIP})
 		ts.NoError(err)
 
 		p3, exists := peer1.app.Conf.GetPeer(peer3.PeerID())
@@ -207,7 +207,7 @@ func TestFriendRequestWithCustomIP(t *testing.T) {
 		peer4 := ts.NewTestPeer(false)
 		ts.ensurePeersAvailableInDHT(peer1, peer4)
 
-		err := peer1.api.SendFriendRequest(peer4.PeerID(), "peer_4", "invalid-ip")
+		err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer4.PeerID(), Alias: "peer_4", IPAddr: "invalid-ip"})
 		ts.Error(err)
 		ts.ErrorContains(err, "Field validation for 'IPAddr' failed")
 	})
@@ -217,7 +217,7 @@ func TestFriendRequestWithCustomIP(t *testing.T) {
 		ts.ensurePeersAvailableInDHT(peer1, peer5)
 
 		// Try to use peer2's IP which is 10.66.0.222
-		err := peer1.api.SendFriendRequest(peer5.PeerID(), "peer_5", "10.66.0.222")
+		err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer5.PeerID(), Alias: "peer_5", IPAddr: "10.66.0.222"})
 		ts.Error(err)
 		ts.ErrorContains(err, "ip 10.66.0.222 is already used by peer")
 	})
@@ -232,11 +232,11 @@ func TestGetAuthRequestsSuggestedIP(t *testing.T) {
 	ts.ensurePeersAvailableInDHT(peer1, peer2)
 	ts.ensurePeersAvailableInDHT(peer1, peer3)
 
-	err := peer2.api.SendFriendRequest(peer1.PeerID(), "peer_1", "")
+	err := peer2.api.SendFriendRequest(entity.FriendRequest{PeerID: peer1.PeerID(), Alias: "peer_1"})
 	ts.NoError(err)
 	time.Sleep(200 * time.Millisecond)
 
-	err = peer3.api.SendFriendRequest(peer1.PeerID(), "peer_1", "")
+	err = peer3.api.SendFriendRequest(entity.FriendRequest{PeerID: peer1.PeerID(), Alias: "peer_1"})
 	ts.NoError(err)
 
 	ts.Eventually(func() bool {
@@ -270,12 +270,12 @@ func TestUniquePeerAlias(t *testing.T) {
 	ts.ensurePeersAvailableInDHT(peer1, peer2)
 	ts.ensurePeersAvailableInDHT(peer2, peer3)
 
-	err := peer1.api.SendFriendRequest(peer2.PeerID(), "peer", "")
+	err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer2.PeerID(), Alias: "peer"})
 	ts.NoError(err)
 
 	time.Sleep(200 * time.Millisecond)
 
-	err = peer1.api.SendFriendRequest(peer3.PeerID(), "peer", "")
+	err = peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer3.PeerID(), Alias: "peer"})
 	ts.EqualError(err, "status code: 400, error: "+api.ErrorPeerAliasIsNotUniq)
 }
 
@@ -408,6 +408,96 @@ func TestUpdateUseAsExitNodeConfig(t *testing.T) {
 	info, err = peer2.api.PeerInfo()
 	ts.NoError(err)
 	ts.Equal("", info.SOCKS5.UsingPeerID)
+}
+
+// TestAddPeerWithExitNodePermission covers granting AllowUsingAsExitNode at add
+// time — in the outgoing invite and in the reply to an incoming one — instead of
+// a follow-up update_settings call. The permission has to reach the other side
+// through the regular status exchange.
+func TestAddPeerWithExitNodePermission(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	peer3 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(peer1, peer2)
+	ts.ensurePeersAvailableInDHT(peer1, peer3)
+
+	t.Run("InviteWithExitNode", func(t *testing.T) {
+		err := peer1.api.SendFriendRequest(entity.FriendRequest{
+			PeerID:               peer2.PeerID(),
+			Alias:                "peer_2",
+			AllowUsingAsExitNode: true,
+		})
+		ts.NoError(err)
+
+		peer2OnPeer1, err := peer1.api.KnownPeerConfig(peer2.PeerID())
+		ts.NoError(err)
+		ts.True(peer2OnPeer1.WeAllowUsingAsExitNode)
+
+		var authRequests []entity.AuthRequest
+		ts.Eventually(func() bool {
+			authRequests, err = peer2.api.AuthRequests()
+			ts.NoError(err)
+			return len(authRequests) == 1
+		}, 15*time.Second, 50*time.Millisecond)
+		err = peer2.api.ReplyFriendRequest(entity.FriendRequestReply{
+			PeerID: authRequests[0].PeerID,
+			Alias:  "peer_1",
+		})
+		ts.NoError(err)
+
+		// peer2 learns the permission from the status exchange, without anyone
+		// calling update_settings.
+		ts.Eventually(func() bool {
+			peer1OnPeer2, err := peer2.api.KnownPeerConfig(peer1.PeerID())
+			ts.NoError(err)
+			return peer1OnPeer2.AllowedUsingAsExitNode
+		}, 15*time.Second, 100*time.Millisecond)
+
+		peer1OnPeer2, err := peer2.api.KnownPeerConfig(peer1.PeerID())
+		ts.NoError(err)
+		ts.False(peer1OnPeer2.WeAllowUsingAsExitNode, "the permission is one-way")
+
+		// Being allowed is not the same as being selected, see clearSelectedExitNode.
+		availableProxies, err := peer2.api.ListAvailableProxies()
+		ts.NoError(err)
+		ts.Len(availableProxies, 1)
+		info, err := peer2.api.PeerInfo()
+		ts.NoError(err)
+		ts.Equal("", info.SOCKS5.UsingPeerID)
+	})
+
+	t.Run("AcceptWithExitNode", func(t *testing.T) {
+		err := peer3.api.SendFriendRequest(entity.FriendRequest{
+			PeerID: peer1.PeerID(),
+			Alias:  "peer_1",
+		})
+		ts.NoError(err)
+
+		var authRequests []entity.AuthRequest
+		ts.Eventually(func() bool {
+			authRequests, err = peer1.api.AuthRequests()
+			ts.NoError(err)
+			return len(authRequests) == 1
+		}, 15*time.Second, 50*time.Millisecond)
+		err = peer1.api.ReplyFriendRequest(entity.FriendRequestReply{
+			PeerID:               authRequests[0].PeerID,
+			Alias:                "peer_3",
+			AllowUsingAsExitNode: true,
+		})
+		ts.NoError(err)
+
+		peer3OnPeer1, err := peer1.api.KnownPeerConfig(peer3.PeerID())
+		ts.NoError(err)
+		ts.True(peer3OnPeer1.WeAllowUsingAsExitNode)
+
+		ts.Eventually(func() bool {
+			peer1OnPeer3, err := peer3.api.KnownPeerConfig(peer1.PeerID())
+			ts.NoError(err)
+			return peer1OnPeer3.AllowedUsingAsExitNode
+		}, 15*time.Second, 100*time.Millisecond)
+	})
 }
 
 func TestSOCKS5ProxyFallbackToOldProtocol(t *testing.T) {

--- a/application_test.go
+++ b/application_test.go
@@ -317,13 +317,21 @@ func TestUpdateUseAsExitNodeConfig(t *testing.T) {
 		return peer2Config.AllowedUsingAsExitNode
 	}, 15*time.Second, 100*time.Millisecond)
 
+	// peer2 allowing us does NOT select it as our exit node — the choice is always explicit
 	info, err = peer1.api.PeerInfo()
 	ts.NoError(err)
-	ts.Equal(peer2.PeerID(), info.SOCKS5.UsingPeerID)
+	ts.Equal("", info.SOCKS5.UsingPeerID)
 
 	availableProxies, err = peer1.api.ListAvailableProxies()
 	ts.NoError(err)
 	ts.Len(availableProxies, 1)
+
+	err = peer1.api.UpdateProxySettings(peer2.PeerID())
+	ts.NoError(err)
+
+	info, err = peer1.api.PeerInfo()
+	ts.NoError(err)
+	ts.Equal(peer2.PeerID(), info.SOCKS5.UsingPeerID)
 
 	// allow from peer1, check that peer2 got our config
 	err = peer1.api.UpdatePeerSettings(entity.UpdatePeerSettingsRequest{
@@ -342,6 +350,11 @@ func TestUpdateUseAsExitNodeConfig(t *testing.T) {
 		return peer1Config.AllowedUsingAsExitNode && peer1Config.WeAllowUsingAsExitNode
 	}, 15*time.Second, 100*time.Millisecond)
 
+	ts.Equal("", peer2.app.SOCKS5.GetProxyPeerID())
+
+	// peer2 has to pick peer1 explicitly too; the checks below proxy through it.
+	err = peer2.api.UpdateProxySettings(peer1.PeerID())
+	ts.NoError(err)
 	ts.Equal(peer1.PeerID(), peer2.app.SOCKS5.GetProxyPeerID())
 
 	// disallow from peer2, check that peer1 got our new config

--- a/application_test.go
+++ b/application_test.go
@@ -2,6 +2,7 @@ package awl
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -16,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/miekg/dns"
 	"github.com/quic-go/quic-go/integrationtests/tools/israce"
 	"golang.org/x/net/proxy"
@@ -25,6 +28,7 @@ import (
 	"github.com/anywherelan/awl/config"
 	"github.com/anywherelan/awl/entity"
 	"github.com/anywherelan/awl/protocol"
+	"github.com/anywherelan/awl/service"
 	"github.com/anywherelan/awl/vpn"
 )
 
@@ -498,6 +502,667 @@ func TestAddPeerWithExitNodePermission(t *testing.T) {
 			return peer1OnPeer3.AllowedUsingAsExitNode
 		}, 15*time.Second, 100*time.Millisecond)
 	})
+}
+
+// TestAddPeerViaInviteLink is the invite link happy path: the creator makes a
+// link, the redeemer adds the creator with the token from it, and both sides end
+// up confirmed with the invite's settings applied — accept_peer is never called
+// anywhere in this test.
+func TestAddPeerViaInviteLink(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	peer3 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+	ts.ensurePeersAvailableInDHT(creator, peer3)
+
+	err := creator.api.UpdateMySettings("alice")
+	ts.NoError(err)
+
+	invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{
+		Label:                "my laptop",
+		Alias:                "laptop",
+		AllowUsingAsExitNode: true,
+		ExpiresInSeconds:     int64(time.Hour.Seconds()),
+	})
+	ts.NoError(err)
+
+	link, err := entity.ParseInviteLink(invite.Link)
+	ts.NoError(err)
+	ts.Equal(creator.PeerID(), link.PeerID)
+	ts.Equal("alice", link.Name)
+
+	err = peer2.api.SendFriendRequest(entity.FriendRequest{
+		PeerID: link.PeerID,
+		Alias:  link.Name,
+		Token:  link.Token,
+	})
+	ts.NoError(err)
+
+	ts.Eventually(func() bool {
+		knownPeer, exists := peer2.app.Conf.GetPeer(creator.PeerID())
+		return exists && knownPeer.Confirmed
+	}, 15*time.Second, 50*time.Millisecond)
+
+	ts.Len(creator.app.AuthStatus.GetIngoingAuthRequests(), 0, "the request was never queued for a manual accept")
+
+	peer2OnCreator, exists := creator.app.Conf.GetPeer(peer2.PeerID())
+	ts.True(exists)
+	ts.True(peer2OnCreator.Confirmed)
+	ts.Equal("laptop", peer2OnCreator.Alias, "the alias comes from the invite")
+	ts.True(peer2OnCreator.WeAllowUsingAsExitNode)
+	ts.Equal(invite.ID, peer2OnCreator.InviteID)
+
+	creatorOnPeer2, exists := peer2.app.Conf.GetPeer(creator.PeerID())
+	ts.True(exists)
+	ts.Empty(creatorOnPeer2.PendingInviteToken, "the token is dropped once we are confirmed")
+	ts.Empty(creatorOnPeer2.InviteID, "the marker belongs to the side that issued the link")
+
+	// The permission from the invite reaches the peer through the status exchange.
+	ts.Eventually(func() bool {
+		knownPeer, _ := peer2.app.Conf.GetPeer(creator.PeerID())
+		return knownPeer.AllowedUsingAsExitNode
+	}, 15*time.Second, 50*time.Millisecond)
+
+	invites, err := creator.api.Invites()
+	ts.NoError(err)
+	ts.Len(invites, 1)
+	ts.Equal(1, invites[0].UsedCount)
+	ts.Equal(entity.InviteStatusUsedUp, invites[0].Status)
+
+	knownPeers, err := creator.api.KnownPeers()
+	ts.NoError(err)
+	ts.Len(knownPeers, 1)
+	ts.Equal(invite.ID, knownPeers[0].InviteID, "the peers list shows which invite let this peer in")
+
+	// An invite whose alias is already taken must not lose the peer: AddPeer
+	// rejects a duplicate alias outright, and nobody would see that error.
+	t.Run("AliasCollision", func(t *testing.T) {
+		secondInvite, err := creator.api.CreateInvite(entity.CreateInviteRequest{Alias: "laptop"})
+		ts.NoError(err)
+		secondLink, err := entity.ParseInviteLink(secondInvite.Link)
+		ts.NoError(err)
+
+		err = peer3.api.SendFriendRequest(entity.FriendRequest{
+			PeerID: secondLink.PeerID,
+			Alias:  "alice",
+			Token:  secondLink.Token,
+		})
+		ts.NoError(err)
+
+		ts.Eventually(func() bool {
+			knownPeer, exists := creator.app.Conf.GetPeer(peer3.PeerID())
+			return exists && knownPeer.Confirmed
+		}, 15*time.Second, 50*time.Millisecond)
+
+		peer3OnCreator, _ := creator.app.Conf.GetPeer(peer3.PeerID())
+		ts.Equal("laptop_0", peer3OnCreator.Alias)
+		ts.Equal(secondInvite.ID, peer3OnCreator.InviteID)
+	})
+}
+
+// TestInviteLinkAlreadyKnownPeer covers the case where the redeemer is already
+// in the creator's KnownPeers (the creator invited it the usual way earlier).
+// An invite only ever lets a new peer in: the peer is already added, with
+// settings the creator chose by hand, and a link presented afterwards changes
+// nothing and costs the link nothing. The connection comes up regardless — the
+// creator answers "you are in my KnownPeers" and the status exchange that
+// follows confirms both sides, exactly as in any mutual add.
+func TestInviteLinkAlreadyKnownPeer(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+
+	// The creator invites peer2 the ordinary way; peer2 never replies to it.
+	err := creator.api.SendFriendRequest(entity.FriendRequest{PeerID: peer2.PeerID(), Alias: "peer_2"})
+	ts.NoError(err)
+	ts.Eventually(func() bool {
+		return len(peer2.app.AuthStatus.GetIngoingAuthRequests()) == 1
+	}, 15*time.Second, 50*time.Millisecond)
+
+	invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{AllowUsingAsExitNode: true})
+	ts.NoError(err)
+	link, err := entity.ParseInviteLink(invite.Link)
+	ts.NoError(err)
+
+	err = peer2.api.SendFriendRequest(entity.FriendRequest{
+		PeerID: link.PeerID,
+		Alias:  "creator",
+		Token:  link.Token,
+	})
+	ts.NoError(err)
+
+	ts.Eventually(func() bool {
+		knownPeer, exists := creator.app.Conf.GetPeer(peer2.PeerID())
+		return exists && knownPeer.Confirmed
+	}, 15*time.Second, 50*time.Millisecond)
+
+	peer2OnCreator, _ := creator.app.Conf.GetPeer(peer2.PeerID())
+	ts.Equal("peer_2", peer2OnCreator.Alias, "the alias the creator chose earlier stays")
+	ts.False(peer2OnCreator.WeAllowUsingAsExitNode, "the link cannot grant anything to a peer already added by hand")
+	ts.Empty(peer2OnCreator.InviteID, "the peer did not come in through the link")
+
+	ts.Eventually(func() bool {
+		knownPeer, exists := peer2.app.Conf.GetPeer(creator.PeerID())
+		return exists && knownPeer.Confirmed
+	}, 15*time.Second, 50*time.Millisecond)
+
+	ts.Len(creator.app.AuthStatus.GetIngoingAuthRequests(), 0, "an already known peer is not queued for a manual accept")
+
+	invites, err := creator.api.Invites()
+	ts.NoError(err)
+	ts.Equal(0, invites[0].UsedCount, "nothing was redeemed")
+	ts.Equal(entity.InviteStatusActive, invites[0].Status, "the link is still good for somebody else")
+}
+
+// TestInviteLinkNotRedeemed checks that a token that no longer works degrades
+// into an ordinary auth request instead of failing outright, and that a
+// rejected token spends nothing.
+func TestInviteLinkNotRedeemed(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	peer3 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+	ts.ensurePeersAvailableInDHT(creator, peer3)
+
+	requirePendingAuthRequest := func(from TestPeer) {
+		var authRequests []entity.AuthRequest
+		ts.Eventually(func() bool {
+			var err error
+			authRequests, err = creator.api.AuthRequests()
+			ts.NoError(err)
+			for _, req := range authRequests {
+				if req.PeerID == from.PeerID() {
+					return true
+				}
+			}
+			return false
+		}, 15*time.Second, 50*time.Millisecond)
+
+		for _, req := range authRequests {
+			ts.Empty(req.Token, "the auth requests endpoint must never hand out a token")
+		}
+		_, exists := creator.app.Conf.GetPeer(from.PeerID())
+		ts.False(exists, "the peer waits for a manual accept")
+	}
+
+	t.Run("Revoked", func(t *testing.T) {
+		invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{})
+		ts.NoError(err)
+		link, err := entity.ParseInviteLink(invite.Link)
+		ts.NoError(err)
+		ts.NoError(creator.api.RevokeInvite(invite.ID))
+
+		err = peer2.api.SendFriendRequest(entity.FriendRequest{
+			PeerID: link.PeerID,
+			Alias:  "creator",
+			Token:  link.Token,
+		})
+		ts.NoError(err)
+
+		requirePendingAuthRequest(peer2)
+
+		stored, exists := creator.app.Conf.GetInvite(invite.ID)
+		ts.True(exists)
+		ts.Equal(0, stored.UsedCount)
+	})
+
+	t.Run("Expired", func(t *testing.T) {
+		invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{ExpiresInSeconds: 60})
+		ts.NoError(err)
+		link, err := entity.ParseInviteLink(invite.Link)
+		ts.NoError(err)
+
+		// Move the expiry into the past instead of waiting for it.
+		creator.app.Conf.Lock()
+		stored := creator.app.Conf.Invites[invite.ID]
+		stored.ExpiresAt = time.Now().Add(-time.Hour)
+		creator.app.Conf.Invites[invite.ID] = stored
+		creator.app.Conf.Unlock()
+
+		err = peer3.api.SendFriendRequest(entity.FriendRequest{
+			PeerID: link.PeerID,
+			Alias:  "creator",
+			Token:  link.Token,
+		})
+		ts.NoError(err)
+
+		requirePendingAuthRequest(peer3)
+
+		stored, _ = creator.app.Conf.GetInvite(invite.ID)
+		ts.Equal(0, stored.UsedCount)
+	})
+}
+
+// TestInviteLinkSingleUse: the second holder of a single-use link gets nothing
+// but the ordinary manual path.
+func TestInviteLinkSingleUse(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	peer3 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+	ts.ensurePeersAvailableInDHT(creator, peer3)
+
+	invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{MaxUses: 1})
+	ts.NoError(err)
+	link, err := entity.ParseInviteLink(invite.Link)
+	ts.NoError(err)
+
+	err = peer2.api.SendFriendRequest(entity.FriendRequest{
+		PeerID: link.PeerID, Alias: "creator", Token: link.Token,
+	})
+	ts.NoError(err)
+	ts.Eventually(func() bool {
+		knownPeer, exists := creator.app.Conf.GetPeer(peer2.PeerID())
+		return exists && knownPeer.Confirmed
+	}, 15*time.Second, 50*time.Millisecond)
+
+	err = peer3.api.SendFriendRequest(entity.FriendRequest{
+		PeerID: link.PeerID, Alias: "creator", Token: link.Token,
+	})
+	ts.NoError(err)
+	ts.Eventually(func() bool {
+		authRequests, err := creator.api.AuthRequests()
+		ts.NoError(err)
+		return len(authRequests) == 1 && authRequests[0].PeerID == peer3.PeerID()
+	}, 15*time.Second, 50*time.Millisecond)
+
+	_, exists := creator.app.Conf.GetPeer(peer3.PeerID())
+	ts.False(exists)
+
+	stored, _ := creator.app.Conf.GetInvite(invite.ID)
+	ts.Equal(1, stored.UsedCount, "a spent link cannot be spent again")
+}
+
+// TestInviteLinkFromBlockedPeer: blocking outranks an invite. The blocked peer
+// is declined as usual, the creator is not even told about it, and the link is
+// left untouched.
+func TestInviteLinkFromBlockedPeer(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+
+	creator.app.Conf.UpsertBlockedPeer(peer2.PeerID(), "unwanted")
+
+	invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{AllowUsingAsExitNode: true})
+	ts.NoError(err)
+	link, err := entity.ParseInviteLink(invite.Link)
+	ts.NoError(err)
+
+	err = peer2.api.SendFriendRequest(entity.FriendRequest{
+		PeerID: link.PeerID,
+		Alias:  "creator",
+		Token:  link.Token,
+	})
+	ts.NoError(err)
+
+	// The declined answer is what tells us the creator has processed the request.
+	ts.Eventually(func() bool {
+		knownPeer, exists := peer2.app.Conf.GetPeer(creator.PeerID())
+		return exists && knownPeer.Declined
+	}, 15*time.Second, 50*time.Millisecond)
+
+	_, exists := creator.app.Conf.GetPeer(peer2.PeerID())
+	ts.False(exists)
+	ts.Len(creator.app.AuthStatus.GetIngoingAuthRequests(), 0, "a blocked peer is not offered for a manual accept either")
+
+	stored, _ := creator.app.Conf.GetInvite(invite.ID)
+	ts.Equal(0, stored.UsedCount, "a blocked peer must not spend a use")
+
+	// A declined peer stops retrying, so its token is not presented again.
+	_, outgoing := peer2.app.AuthStatus.GetAuthRequestCounts()
+	ts.Equal(0, outgoing)
+}
+
+// TestRemovePeerStopsInviteTokenRetries: removing a peer we added by link must
+// also stop the auth retries carrying the invite token. Otherwise the token
+// keeps being handed to a peer the user got rid of, and once that peer comes
+// online it auto-accepts a request nobody wanted any more.
+func TestRemovePeerStopsInviteTokenRetries(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+
+	invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{})
+	ts.NoError(err)
+	link, err := entity.ParseInviteLink(invite.Link)
+	ts.NoError(err)
+
+	// Revoked, so the creator queues a manual request instead of confirming and
+	// the redeemer keeps retrying with the token.
+	ts.NoError(creator.api.RevokeInvite(invite.ID))
+
+	err = peer2.api.SendFriendRequest(entity.FriendRequest{
+		PeerID: link.PeerID,
+		Alias:  "creator",
+		Token:  link.Token,
+	})
+	ts.NoError(err)
+
+	ts.Eventually(func() bool {
+		_, outgoing := peer2.app.AuthStatus.GetAuthRequestCounts()
+		return outgoing == 1
+	}, 15*time.Second, 50*time.Millisecond)
+
+	err = peer2.api.RemovePeer(creator.PeerID())
+	ts.NoError(err)
+
+	_, outgoing := peer2.app.AuthStatus.GetAuthRequestCounts()
+	ts.Equal(0, outgoing, "no retry may carry the token to a removed peer")
+}
+
+// TestInviteLinkWithAutoAccept: a valid token applies the invite's settings even
+// when AutoAcceptAuthRequests would have let the peer in anyway. Without this,
+// turning on the global auto-accept would silently drop the invite's settings
+// and leave the link unspent.
+func TestInviteLinkWithAutoAccept(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+
+	creator.app.Conf.Lock()
+	creator.app.Conf.P2pNode.AutoAcceptAuthRequests = true
+	creator.app.Conf.Unlock()
+
+	// Plain auto-accept names a peer after itself, so an alias of "bob" would
+	// mean the invite was ignored.
+	err := peer2.api.UpdateMySettings("bob")
+	ts.NoError(err)
+
+	invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{
+		Alias:                "laptop",
+		AllowUsingAsExitNode: true,
+	})
+	ts.NoError(err)
+	link, err := entity.ParseInviteLink(invite.Link)
+	ts.NoError(err)
+
+	err = peer2.api.SendFriendRequest(entity.FriendRequest{
+		PeerID: link.PeerID,
+		Alias:  "creator",
+		Token:  link.Token,
+	})
+	ts.NoError(err)
+
+	ts.Eventually(func() bool {
+		knownPeer, exists := creator.app.Conf.GetPeer(peer2.PeerID())
+		return exists && knownPeer.Confirmed
+	}, 15*time.Second, 50*time.Millisecond)
+
+	peer2OnCreator, _ := creator.app.Conf.GetPeer(peer2.PeerID())
+	ts.Equal("laptop", peer2OnCreator.Alias, "the invite's alias wins over the auto-accept default")
+	ts.True(peer2OnCreator.WeAllowUsingAsExitNode)
+	ts.Equal(invite.ID, peer2OnCreator.InviteID)
+
+	stored, _ := creator.app.Conf.GetInvite(invite.ID)
+	ts.Equal(1, stored.UsedCount, "the link is spent, not bypassed by auto-accept")
+}
+
+// TestInviteLinkUseAccounting covers who spends a use of a link and who does not.
+func TestInviteLinkUseAccounting(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	peer3 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+	ts.ensurePeersAvailableInDHT(creator, peer3)
+
+	invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{MaxUses: 2})
+	ts.NoError(err)
+	link, err := entity.ParseInviteLink(invite.Link)
+	ts.NoError(err)
+
+	// One link rolling out several devices: both are added, and only then is it
+	// used up.
+	t.Run("MultiUse", func(t *testing.T) {
+		for _, redeemer := range []TestPeer{peer2, peer3} {
+			err = redeemer.api.SendFriendRequest(entity.FriendRequest{
+				PeerID: link.PeerID,
+				Alias:  "creator",
+				Token:  link.Token,
+			})
+			ts.NoError(err)
+
+			ts.Eventually(func() bool {
+				knownPeer, exists := creator.app.Conf.GetPeer(redeemer.PeerID())
+				return exists && knownPeer.Confirmed
+			}, 15*time.Second, 50*time.Millisecond)
+
+			knownPeer, _ := creator.app.Conf.GetPeer(redeemer.PeerID())
+			ts.Equal(invite.ID, knownPeer.InviteID)
+		}
+
+		invites, err := creator.api.Invites()
+		ts.NoError(err)
+		ts.Len(invites, 1)
+		ts.Equal(2, invites[0].UsedCount)
+		ts.Equal(entity.InviteStatusUsedUp, invites[0].Status)
+	})
+
+	// A peer already in KnownPeers has nothing to redeem: a retry carrying a
+	// token must not eat a use of an unrelated link.
+	t.Run("KnownPeerKeepsUse", func(t *testing.T) {
+		freshInvite, err := creator.api.CreateInvite(entity.CreateInviteRequest{})
+		ts.NoError(err)
+		freshLink, err := entity.ParseInviteLink(freshInvite.Link)
+		ts.NoError(err)
+
+		err = peer2.app.AuthStatus.SendAuthRequest(context.Background(), creator.app.P2p.PeerID(), protocol.AuthPeer{
+			Name:  "peer_2",
+			Token: freshLink.Token,
+		})
+		ts.NoError(err)
+
+		stored, _ := creator.app.Conf.GetInvite(freshInvite.ID)
+		ts.Equal(0, stored.UsedCount)
+
+		peer2OnCreator, _ := creator.app.Conf.GetPeer(peer2.PeerID())
+		ts.Equal(invite.ID, peer2OnCreator.InviteID, "the marker keeps pointing at the link the peer actually came from")
+	})
+}
+
+// TestInviteTokenSurvivesRestart: a peer added through a link stays unconfirmed
+// until the creator sees it, so its auth request is retried in the background —
+// and that retry is rebuilt from the config on every start
+// (restoreOutgoingAuths). If the token were not stored alongside the peer, a
+// restart before the creator ever came online would leave a dead "not accepted"
+// entry that no retry could revive.
+//
+// The restart is imitated rather than performed: every test peer gets a fresh
+// data dir, but the config modifier runs before app.Init — hence before
+// AuthStatus reads the config, which is the whole of what this test is about.
+func TestInviteTokenSurvivesRestart(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	err := creator.api.UpdateMySettings("alice")
+	ts.NoError(err)
+
+	invite, err := creator.api.CreateInvite(entity.CreateInviteRequest{
+		Alias:                "laptop",
+		AllowUsingAsExitNode: true,
+	})
+	ts.NoError(err)
+	link, err := entity.ParseInviteLink(invite.Link)
+	ts.NoError(err)
+
+	peer2 := ts.NewTestPeerWithConfig(func(conf *config.Config) {
+		// What AddPeer stored before the restart, plus the fields setDefaults
+		// fills in while loading a config from disk.
+		conf.KnownPeers[link.PeerID] = config.KnownPeer{
+			PeerID:             link.PeerID,
+			Name:               link.Name,
+			Alias:              link.Name,
+			IPAddr:             conf.GenerateNextIpAddr(),
+			DomainName:         awldns.TrimDomainName(link.Name),
+			CreatedAt:          time.Now(),
+			PendingInviteToken: link.Token,
+		}
+	})
+	ts.ensurePeersAvailableInDHT(creator, peer2)
+
+	// Connecting by hand rather than waiting for MaintainBackgroundConnections,
+	// which does the same thing up to five seconds later: either way it is
+	// onPeerConnected that sends the restored auth request.
+	err = peer2.app.P2p.ConnectPeer(context.Background(), creator.app.P2p.PeerID())
+	ts.NoError(err)
+
+	ts.Eventually(func() bool {
+		knownPeer, exists := creator.app.Conf.GetPeer(peer2.PeerID())
+		return exists && knownPeer.Confirmed
+	}, 15*time.Second, 50*time.Millisecond)
+
+	peer2OnCreator, _ := creator.app.Conf.GetPeer(peer2.PeerID())
+	ts.Equal("laptop", peer2OnCreator.Alias, "the restored retry carried the token, so the invite applied")
+	ts.True(peer2OnCreator.WeAllowUsingAsExitNode)
+	ts.Equal(invite.ID, peer2OnCreator.InviteID)
+
+	ts.Eventually(func() bool {
+		knownPeer, _ := peer2.app.Conf.GetPeer(creator.PeerID())
+		return knownPeer.Confirmed && knownPeer.PendingInviteToken == ""
+	}, 15*time.Second, 50*time.Millisecond)
+
+	invites, err := creator.api.Invites()
+	ts.NoError(err)
+	ts.Equal(1, invites[0].UsedCount)
+}
+
+// TestAddPeerRedeemsInvite exercises the redemption invariant at the one place
+// that owns it: an invite is spent inside AddPeer's critical section, so a use
+// can only ever be counted together with the peer that spent it. None of these
+// races can be provoked through the network, hence the direct calls.
+func TestAddPeerRedeemsInvite(t *testing.T) {
+	ts := NewTestSuite(t)
+
+	creator := ts.NewTestPeer(false)
+	auth := creator.app.AuthStatus
+
+	// Two holders of a single-use link arriving together: one gets in, the rest
+	// cost the link nothing.
+	t.Run("Concurrent", func(t *testing.T) {
+		invite, err := creator.app.Conf.CreateInvite(config.CreateInviteParams{
+			MaxUses:              1,
+			Alias:                "laptop",
+			AllowUsingAsExitNode: true,
+		})
+		ts.NoError(err)
+
+		const redeemers = 20
+		peerIDs := make([]peer.ID, redeemers)
+		for i := range peerIDs {
+			peerIDs[i] = generateTestPeerID(ts)
+		}
+
+		var wg sync.WaitGroup
+		errs := make([]error, redeemers)
+		start := make(chan struct{})
+		for i, peerID := range peerIDs {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				errs[i] = auth.AddPeer(context.Background(), service.AddPeerParams{
+					PeerID:            peerID,
+					Name:              fmt.Sprintf("redeemer-%d", i),
+					Confirmed:         true,
+					UniquifyAlias:     true,
+					RedeemInviteToken: invite.Token,
+				})
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		succeeded := 0
+		for _, err := range errs {
+			if err == nil {
+				succeeded++
+			}
+		}
+		ts.Equal(1, succeeded)
+
+		added := make([]config.KnownPeer, 0, 1)
+		for _, peerID := range peerIDs {
+			if knownPeer, exists := creator.app.Conf.GetPeer(peerID.String()); exists {
+				added = append(added, knownPeer)
+			}
+		}
+		ts.Len(added, 1, "a single-use invite admits exactly one peer")
+		ts.Equal("laptop", added[0].Alias, "its settings come from the invite")
+		ts.True(added[0].WeAllowUsingAsExitNode)
+		ts.Equal(invite.ID, added[0].InviteID)
+
+		stored, _ := creator.app.Conf.GetInvite(invite.ID)
+		ts.Equal(1, stored.UsedCount)
+	})
+
+	// A retry meeting onPeerConnected makes two auth streams from one peer; the
+	// loser gets "peer has already been added" and must not burn a use.
+	t.Run("AlreadyAdded", func(t *testing.T) {
+		invite, err := creator.app.Conf.CreateInvite(config.CreateInviteParams{MaxUses: 2})
+		ts.NoError(err)
+
+		params := service.AddPeerParams{
+			PeerID:            generateTestPeerID(ts),
+			Name:              "twice",
+			Confirmed:         true,
+			UniquifyAlias:     true,
+			RedeemInviteToken: invite.Token,
+		}
+		ts.NoError(auth.AddPeer(context.Background(), params))
+		ts.Error(auth.AddPeer(context.Background(), params))
+
+		stored, _ := creator.app.Conf.GetInvite(invite.ID)
+		ts.Equal(1, stored.UsedCount)
+	})
+
+	// The check in the auth handler is advisory only. If the link goes bad
+	// between it and the redemption, the peer is not quietly let in without what
+	// the link promised.
+	t.Run("Unusable", func(t *testing.T) {
+		invite, err := creator.app.Conf.CreateInvite(config.CreateInviteParams{MaxUses: 1})
+		ts.NoError(err)
+		ts.True(creator.app.Conf.RevokeInvite(invite.ID))
+
+		peerID := generateTestPeerID(ts)
+		err = auth.AddPeer(context.Background(), service.AddPeerParams{
+			PeerID:            peerID,
+			Name:              "revoked",
+			Confirmed:         true,
+			UniquifyAlias:     true,
+			RedeemInviteToken: invite.Token,
+		})
+		ts.ErrorIs(err, config.ErrInviteRevoked)
+
+		_, exists := creator.app.Conf.GetPeer(peerID.String())
+		ts.False(exists)
+	})
+}
+
+// generateTestPeerID returns a valid peer ID for peers that never connect.
+// AddPeer feeds the peer list, the DNS table and the VPN, so a fabricated
+// string would be planted in all three.
+func generateTestPeerID(ts *TestSuite) peer.ID {
+	_, pubKey, err := crypto.GenerateEd25519Key(rand.Reader)
+	ts.NoError(err)
+	peerID, err := peer.IDFromPublicKey(pubKey)
+	ts.NoError(err)
+
+	return peerID
 }
 
 func TestSOCKS5ProxyFallbackToOldProtocol(t *testing.T) {

--- a/awlevent/awlevent.go
+++ b/awlevent/awlevent.go
@@ -3,8 +3,9 @@ package awlevent
 import (
 	"context"
 
-	"github.com/anywherelan/awl/protocol"
 	"github.com/libp2p/go-libp2p/core/event"
+
+	"github.com/anywherelan/awl/protocol"
 )
 
 type Bus = event.Bus
@@ -16,6 +17,13 @@ type KnownPeerChanged struct {
 type ReceivedAuthRequest struct {
 	protocol.AuthPeer
 	PeerID string
+}
+
+// InviteRedeemed is emitted when a peer joins through one of our invite links
+// (config.Invite), carrying the non-secret invite ID.
+type InviteRedeemed struct {
+	PeerID   string
+	InviteID string
 }
 
 // VPNGatewayConnectivityChanged is emitted (client mode only) when the

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -230,14 +230,19 @@ func (a *Application) init() {
 						Usage: "Invite peer or accept existing invitation from this peer",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
+								Name:     "link",
+								Usage:    "invite link to add the peer by, instead of pid: awl://invite?p=...",
+								Required: false,
+							},
+							&cli.StringFlag{
 								Name:     "pid",
 								Usage:    "peer id",
-								Required: true,
+								Required: false,
 							},
 							&cli.StringFlag{
 								Name:     "name",
-								Usage:    "peer name",
-								Required: true,
+								Usage:    "peer name, required unless the link carries one",
+								Required: false,
 							},
 							&cli.StringFlag{
 								Name:     "ip",
@@ -252,7 +257,13 @@ func (a *Application) init() {
 						},
 						Before: a.initApiConnection,
 						Action: func(c *cli.Context) error {
-							return addPeer(a.api, c.String("pid"), c.String("name"), c.String("ip"), c.Bool("allow-exit-node"), c.App.Writer)
+							return addPeer(a.api, addPeerParams{
+								Link:                 c.String("link"),
+								PeerID:               c.String("pid"),
+								Alias:                c.String("name"),
+								IPAddr:               c.String("ip"),
+								AllowUsingAsExitNode: c.Bool("allow-exit-node"),
+							}, c.App.Writer)
 						},
 					},
 					{
@@ -373,6 +384,91 @@ func (a *Application) init() {
 						Before: a.initApiAndPeerIdRequired,
 						Action: func(c *cli.Context) error {
 							return setAllowUsingAsExitNode(a.api, c.String("pid"), c.Bool("allow"), c.App.Writer)
+						},
+					},
+					{
+						Name:  "invite",
+						Usage: "Group of commands to work with invite links: share one and the peer is added automatically",
+						Subcommands: []*cli.Command{
+							{
+								Name:  "create",
+								Usage: "Create an invite link and print it with a QR code",
+								Flags: []cli.Flag{
+									&cli.IntFlag{
+										Name:     "uses",
+										Usage:    "how many peers may join through the link, up to 100",
+										Required: false,
+										Value:    1,
+									},
+									&cli.StringFlag{
+										Name:     "expires",
+										Usage:    "how long the link lives, up to 365d: a duration such as 30m, 24h, 7d, 1d6h, or 'never'",
+										Required: false,
+										Value:    "24h",
+									},
+									&cli.StringFlag{
+										Name:     "alias",
+										Usage:    "optional. name to give the peer that joins, single-use links only, up to 100 characters",
+										Required: false,
+									},
+									&cli.BoolFlag{
+										Name:     "allow-exit-node",
+										Usage:    "allow the joining peer to use your device as exit node (as VPN Gateway or SOCKS5 proxy)",
+										Required: false,
+									},
+									&cli.StringFlag{
+										Name:     "label",
+										Usage:    "note for yourself, shown in the list, up to 100 characters",
+										Required: false,
+									},
+									&cli.BoolFlag{
+										Name:     "no-qr",
+										Usage:    "print the link without a QR code",
+										Required: false,
+									},
+								},
+								Before: a.initApiConnection,
+								Action: func(c *cli.Context) error {
+									return createInvite(a.api, createInviteParams{
+										Uses:                 c.Int("uses"),
+										Expires:              c.String("expires"),
+										Alias:                c.String("alias"),
+										AllowUsingAsExitNode: c.Bool("allow-exit-node"),
+										Label:                c.String("label"),
+										ShowQR:               !c.Bool("no-qr"),
+									}, c.App.Writer)
+								},
+							},
+							{
+								Name:  "list",
+								Usage: "Print all invite links, spent ones included",
+								Flags: []cli.Flag{
+									&cli.BoolFlag{
+										Name:     "show-links",
+										Usage:    "print the links themselves, secrets and all",
+										Required: false,
+									},
+								},
+								Before: a.initApiConnection,
+								Action: func(c *cli.Context) error {
+									return printInvites(a.api, c.Bool("show-links"), c.App.Writer)
+								},
+							},
+							{
+								Name:  "revoke",
+								Usage: "Stop an invite link from accepting new peers; peers already added stay",
+								Flags: []cli.Flag{
+									&cli.StringFlag{
+										Name:     "id",
+										Usage:    "invite id, as printed by 'peers invite list'",
+										Required: true,
+									},
+								},
+								Before: a.initApiConnection,
+								Action: func(c *cli.Context) error {
+									return revokeInvite(a.api, c.String("id"), c.App.Writer)
+								},
+							},
 						},
 					},
 				},

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -244,10 +244,15 @@ func (a *Application) init() {
 								Usage:    "override peer IP address",
 								Required: false,
 							},
+							&cli.BoolFlag{
+								Name:     "allow-exit-node",
+								Usage:    "allow this peer to use your device as exit node (as socks5 proxy)",
+								Required: false,
+							},
 						},
 						Before: a.initApiConnection,
 						Action: func(c *cli.Context) error {
-							return addPeer(a.api, c.String("pid"), c.String("name"), c.String("ip"), c.App.Writer)
+							return addPeer(a.api, c.String("pid"), c.String("name"), c.String("ip"), c.Bool("allow-exit-node"), c.App.Writer)
 						},
 					},
 					{

--- a/cli/invites.go
+++ b/cli/invites.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mdp/qrterminal/v3"
+	"github.com/olekukonko/tablewriter"
+
+	"github.com/anywherelan/awl/api/apiclient"
+	"github.com/anywherelan/awl/entity"
+)
+
+// inviteNeverExpires is what --expires takes instead of a duration to make a
+// link without an expiry, and what the list prints for one.
+const inviteNeverExpires = "never"
+
+// createInviteParams is the flags of `peers invite create`, with the Expires
+// still in the human form the flag takes.
+type createInviteParams struct {
+	Uses                 int
+	Expires              string
+	Alias                string
+	AllowUsingAsExitNode bool
+	Label                string
+	ShowQR               bool
+}
+
+func createInvite(api *apiclient.Client, params createInviteParams, w io.Writer) error {
+	expiresInSeconds, err := parseInviteExpiry(params.Expires)
+	if err != nil {
+		return err
+	}
+
+	invite, err := api.CreateInvite(entity.CreateInviteRequest{
+		MaxUses:              params.Uses,
+		ExpiresInSeconds:     expiresInSeconds,
+		Alias:                params.Alias,
+		AllowUsingAsExitNode: params.AllowUsingAsExitNode,
+		Label:                params.Label,
+	})
+	if err != nil {
+		return err
+	}
+
+	// The link goes first and alone on its line, so that it can be picked out of the output by eye or by a script.
+	fmt.Fprintln(w, invite.Link)
+	fmt.Fprintln(w, formatInviteSummary(*invite))
+
+	if params.ShowQR {
+		qrterminal.GenerateHalfBlock(invite.Link, qrterminal.M, w)
+	}
+
+	return nil
+}
+
+// printInvites lists the invites. Links are printed only on demand.
+func printInvites(api *apiclient.Client, showLinks bool, w io.Writer) error {
+	invites, err := api.Invites()
+	if err != nil {
+		return err
+	}
+	if len(invites) == 0 {
+		fmt.Fprintln(w, "you have no invite links")
+		return nil
+	}
+
+	headers := []string{"id", "label", "uses", "expires", "status", "grants"}
+	if showLinks {
+		headers = append(headers, "link")
+	}
+
+	table := tablewriter.NewWriter(w)
+	table.SetAutoWrapText(false)
+	table.SetBorders(tablewriter.Border{Left: false, Top: false, Right: false, Bottom: false})
+	table.SetHeader(headers)
+
+	for _, invite := range invites {
+		row := []string{
+			invite.ID,
+			invite.Label,
+			formatInviteUses(invite),
+			formatInviteExpiry(invite.ExpiresAt),
+			invite.Status,
+			formatInviteGrants(invite),
+		}
+		if showLinks {
+			row = append(row, invite.Link)
+		}
+		table.Append(row)
+	}
+	table.Render()
+
+	return nil
+}
+
+// revokeInvite closes an invite by ID.
+func revokeInvite(api *apiclient.Client, id string, w io.Writer) error {
+	// IDs are lowercase hex, and this one was most likely retyped off a screen.
+	err := api.RevokeInvite(strings.ToLower(strings.TrimSpace(id)))
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(w, "invite revoked: it accepts no new peers, peers already added through it stay")
+	return nil
+}
+
+// formatInviteSummary describes an invite in one line: what it costs to use it
+// up, and what it grants to whoever does.
+func formatInviteSummary(invite entity.InviteResponse) string {
+	parts := []string{
+		"id " + invite.ID,
+		"uses " + formatInviteUses(invite),
+		"expires " + formatInviteExpiry(invite.ExpiresAt),
+	}
+	if invite.Alias != "" {
+		parts = append(parts, fmt.Sprintf("alias %q", invite.Alias))
+	}
+	if invite.AllowUsingAsExitNode {
+		parts = append(parts, "may use you as exit node")
+	}
+
+	return strings.Join(parts, " | ")
+}
+
+func formatInviteUses(invite entity.InviteResponse) string {
+	return fmt.Sprintf("%d/%d", invite.UsedCount, invite.MaxUses)
+}
+
+// formatInviteGrants renders, for the list, what a link decides in advance for whoever redeems it.
+func formatInviteGrants(invite entity.InviteResponse) string {
+	var parts []string
+	if invite.AllowUsingAsExitNode {
+		parts = append(parts, "exit node")
+	}
+	if invite.Alias != "" {
+		parts = append(parts, fmt.Sprintf("alias %q", invite.Alias))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// formatInviteExpiry renders the expiry as a date plus the time left.
+func formatInviteExpiry(expiresAt time.Time) string {
+	if expiresAt.IsZero() {
+		return inviteNeverExpires
+	}
+
+	date := expiresAt.Local().Format("2006-01-02 15:04")
+	left := time.Until(expiresAt)
+	if left <= 0 {
+		return date + " (expired)"
+	}
+
+	return fmt.Sprintf("%s (in %s)", date, formatInviteTimeLeft(left))
+}
+
+// formatInviteTimeLeft renders how long a link still has in its largest unit
+// alone, rounded to the nearest one: "24h", "6d". Rounded, not truncated, so
+// that a link just made with --expires 24h does not greet its author with
+// "23h". Not formatUptime, which is built for an uptime and counts down to the
+// second — nobody reads an invite that closely, and the seconds would only
+// churn in the table.
+func formatInviteTimeLeft(left time.Duration) string {
+	const day = 24 * time.Hour
+
+	switch {
+	case left >= day:
+		return fmt.Sprintf("%dd", left.Round(day)/day)
+	case left >= time.Hour:
+		// Rounding can carry the value into the next unit, and the unit it lands
+		// in is the one to say it in: "1d", never "24h".
+		if left.Round(time.Hour) >= day {
+			return "1d"
+		}
+		return fmt.Sprintf("%dh", left.Round(time.Hour)/time.Hour)
+	case left >= time.Minute:
+		if left.Round(time.Minute) >= time.Hour {
+			return "1h"
+		}
+		return fmt.Sprintf("%dm", left.Round(time.Minute)/time.Minute)
+	}
+
+	return "<1m"
+}
+
+// parseInviteExpiry turns the --expires flag into the seconds the API takes.
+func parseInviteExpiry(value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if strings.EqualFold(value, inviteNeverExpires) {
+		return 0, nil
+	}
+
+	duration, err := parseDurationWithDays(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid expires value '%s': use a duration such as 30m, 24h, 7d, 1d6h, or '%s'", value, inviteNeverExpires)
+	}
+	if duration < time.Second {
+		return 0, fmt.Errorf("expires must be at least 1s, or '%s' for a link that never expires", inviteNeverExpires)
+	}
+
+	return int64(duration.Seconds()), nil
+}
+
+// parseDurationWithDays is time.ParseDuration with one unit added: "d", a day
+// of 24h, which the standard parser has no unit above an hour for — and a link
+// that lives a week is an ordinary thing to ask for.
+//
+// Lifted from Caddy's caddy.ParseDuration (caddyserver/caddy, caddy.go), minus
+// its length guard on the input, which here is a local flag. Every "<n>d" is
+// rewritten into the equal number of hours and the standard parser does the
+// rest, so the other units, the fractions and the error messages are all the
+// ones people already know. It composes because time.ParseDuration sums
+// repeated units: "1d6h" becomes "24h6h", which is 30h.
+func parseDurationWithDays(s string) (time.Duration, error) {
+	var inNumber bool
+	var numStart int
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if ch == 'd' {
+			days, err := strconv.ParseFloat(s[numStart:i], 64)
+			if err != nil {
+				return 0, err
+			}
+			hours := strconv.FormatFloat(days*24, 'f', -1, 64)
+			s = s[:numStart] + hours + "h" + s[i+1:]
+			i--
+			continue
+		}
+		if !inNumber {
+			numStart = i
+		}
+		inNumber = (ch >= '0' && ch <= '9') || ch == '.' || ch == '-' || ch == '+'
+	}
+
+	return time.ParseDuration(s)
+}

--- a/cli/me.go
+++ b/cli/me.go
@@ -201,9 +201,16 @@ func printPeerId(api *apiclient.Client, w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(w, "your peer id: %s\n", info.PeerID)
 
-	qrterminal.GenerateHalfBlock(info.PeerID, qrterminal.M, w)
+	// A link without a token: it identifies us and carries our name, so the
+	// other side can fill the add form from a single scan, but it grants
+	// nothing on its own — that is what `peers invite create` is for.
+	link := entity.BuildInviteLink(info.PeerID, "", info.Name)
+
+	fmt.Fprintf(w, "your peer id: %s\n", info.PeerID)
+	fmt.Fprintf(w, "your link:    %s\n", link)
+
+	qrterminal.GenerateHalfBlock(link, qrterminal.M, w)
 
 	return nil
 }

--- a/cli/peers.go
+++ b/cli/peers.go
@@ -171,44 +171,101 @@ func getPeerIdByAlias(api *apiclient.Client, alias string) (string, error) {
 	return "", fmt.Errorf("can't find peer with name \"%s\"", alias)
 }
 
-func addPeer(api *apiclient.Client, peerID, alias, ipAddr string, allowUsingAsExitNode bool, w io.Writer) error {
+// addPeerParams is the flags of `peers add`. A peer is named either by an
+// invite link or by a peer id; the rest is optional.
+type addPeerParams struct {
+	// Link is an invite link. With a token in it the peer auto accepts us.
+	// Without a token, link is merely a peer id with a name, and the remote peer needs to accept us.
+	Link                 string
+	PeerID               string
+	Alias                string
+	IPAddr               string
+	AllowUsingAsExitNode bool
+	// token is resolved from Link
+	token string
+}
+
+func addPeer(api *apiclient.Client, params addPeerParams, w io.Writer) error {
+	params, err := resolveAddPeerTarget(params)
+	if err != nil {
+		return err
+	}
+
 	authRequests, err := api.AuthRequests()
 	if err != nil {
 		return err
 	}
 	hasRequest := false
 	for _, req := range authRequests {
-		if req.PeerID == peerID {
+		if req.PeerID == params.PeerID {
 			hasRequest = true
 			break
 		}
 	}
 	if hasRequest {
+		// Drop the token on purpose: a peer that already sent us a request
+		// already knows us, so FriendRequestReply intentionally carries no token.
 		err := api.ReplyFriendRequest(entity.FriendRequestReply{
-			PeerID:               peerID,
-			Alias:                alias,
-			IPAddr:               ipAddr,
-			AllowUsingAsExitNode: allowUsingAsExitNode,
+			PeerID:               params.PeerID,
+			Alias:                params.Alias,
+			IPAddr:               params.IPAddr,
+			AllowUsingAsExitNode: params.AllowUsingAsExitNode,
 		})
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintln(w, "user added to friends list successfully")
+		fmt.Fprintf(w, "successfully accepted existing invitation from the device '%s'\n", params.Alias)
 		return nil
 	}
 
 	err = api.SendFriendRequest(entity.FriendRequest{
-		PeerID:               peerID,
-		Alias:                alias,
-		IPAddr:               ipAddr,
-		AllowUsingAsExitNode: allowUsingAsExitNode,
+		PeerID:               params.PeerID,
+		Alias:                params.Alias,
+		IPAddr:               params.IPAddr,
+		AllowUsingAsExitNode: params.AllowUsingAsExitNode,
+		Token:                params.token,
 	})
 	if err != nil {
 		return err
 	}
+
+	if params.token != "" {
+		fmt.Fprintln(w, "friend request sent with the invite link; the peer accepts it automatically once it is online")
+		return nil
+	}
 	fmt.Fprintln(w, "friend request sent successfully")
 	return nil
+}
+
+// resolveAddPeerTarget validate params and resolves an invite link.
+func resolveAddPeerTarget(params addPeerParams) (addPeerParams, error) {
+	params.Alias = strings.TrimSpace(params.Alias)
+
+	if params.Link != "" && params.PeerID != "" {
+		return params, errors.New("link and pid flags are mutually exclusive: a link already has PeerID")
+	}
+
+	if params.Link != "" {
+		link, err := entity.ParseInviteLink(params.Link)
+		if err != nil {
+			return params, err
+		}
+		params.token = link.Token
+		params.PeerID = link.PeerID
+		if params.Alias == "" {
+			params.Alias = strings.TrimSpace(link.Name)
+		}
+	}
+
+	switch {
+	case params.PeerID == "":
+		return params, errors.New("either link or pid flag is required")
+	case params.Alias == "":
+		return params, errors.New("name flag is required: the link carries no name to fall back on")
+	}
+
+	return params, nil
 }
 
 func removePeer(api *apiclient.Client, peerID string, w io.Writer) error {

--- a/cli/peers.go
+++ b/cli/peers.go
@@ -171,7 +171,7 @@ func getPeerIdByAlias(api *apiclient.Client, alias string) (string, error) {
 	return "", fmt.Errorf("can't find peer with name \"%s\"", alias)
 }
 
-func addPeer(api *apiclient.Client, peerID, alias, ipAddr string, w io.Writer) error {
+func addPeer(api *apiclient.Client, peerID, alias, ipAddr string, allowUsingAsExitNode bool, w io.Writer) error {
 	authRequests, err := api.AuthRequests()
 	if err != nil {
 		return err
@@ -184,7 +184,12 @@ func addPeer(api *apiclient.Client, peerID, alias, ipAddr string, w io.Writer) e
 		}
 	}
 	if hasRequest {
-		err := api.ReplyFriendRequest(peerID, alias, false, ipAddr)
+		err := api.ReplyFriendRequest(entity.FriendRequestReply{
+			PeerID:               peerID,
+			Alias:                alias,
+			IPAddr:               ipAddr,
+			AllowUsingAsExitNode: allowUsingAsExitNode,
+		})
 		if err != nil {
 			return err
 		}
@@ -193,7 +198,12 @@ func addPeer(api *apiclient.Client, peerID, alias, ipAddr string, w io.Writer) e
 		return nil
 	}
 
-	err = api.SendFriendRequest(peerID, alias, ipAddr)
+	err = api.SendFriendRequest(entity.FriendRequest{
+		PeerID:               peerID,
+		Alias:                alias,
+		IPAddr:               ipAddr,
+		AllowUsingAsExitNode: allowUsingAsExitNode,
+	})
 	if err != nil {
 		return err
 	}

--- a/cli_test.go
+++ b/cli_test.go
@@ -167,7 +167,7 @@ func TestCLI_PeersRequests_WithRequest(t *testing.T) {
 	peer2 := ts.NewTestPeer(false)
 	ts.ensurePeersAvailableInDHT(peer1, peer2)
 
-	err := peer2.api.SendFriendRequest(peer1.PeerID(), "peer_1", "")
+	err := peer2.api.SendFriendRequest(entity.FriendRequest{PeerID: peer1.PeerID(), Alias: "peer_1"})
 	ts.NoError(err)
 
 	ts.Eventually(func() bool {
@@ -189,6 +189,8 @@ func TestCLI_PeersRequests_WithRequest(t *testing.T) {
 
 // TestCLI_PeersAdd covers the two branches of "peers add": sending a new request,
 // and accepting an existing one. Each subtest creates independent peers.
+// --allow-exit-node has to work in both branches — they call different API
+// endpoints — and the bare form (no "=true") has to set it.
 func TestCLI_PeersAdd(t *testing.T) {
 	t.Run("SendRequest", func(t *testing.T) {
 		ts := NewTestSuite(t)
@@ -199,6 +201,25 @@ func TestCLI_PeersAdd(t *testing.T) {
 		out, err := runCLI(ts, peer1, "peers", "add", "--pid", peer2.PeerID(), "--name", "peer_2")
 		require.NoError(t, err)
 		require.Equal(t, "friend request sent successfully\n", out)
+
+		pcfg, err := peer1.api.KnownPeerConfig(peer2.PeerID())
+		require.NoError(t, err)
+		require.False(t, pcfg.WeAllowUsingAsExitNode)
+	})
+
+	t.Run("SendRequestAllowingExitNode", func(t *testing.T) {
+		ts := NewTestSuite(t)
+		peer1 := ts.NewTestPeer(false)
+		peer2 := ts.NewTestPeer(false)
+		ts.ensurePeersAvailableInDHT(peer1, peer2)
+
+		out, err := runCLI(ts, peer1, "peers", "add", "--pid", peer2.PeerID(), "--name", "peer_2", "--allow-exit-node")
+		require.NoError(t, err)
+		require.Equal(t, "friend request sent successfully\n", out)
+
+		pcfg, err := peer1.api.KnownPeerConfig(peer2.PeerID())
+		require.NoError(t, err)
+		require.True(t, pcfg.WeAllowUsingAsExitNode)
 	})
 
 	t.Run("AcceptRequest", func(t *testing.T) {
@@ -208,7 +229,7 @@ func TestCLI_PeersAdd(t *testing.T) {
 		ts.ensurePeersAvailableInDHT(peer1, peer2)
 
 		// peer2 sends to peer1 first; CLI add from peer1 should detect and accept it
-		err := peer2.api.SendFriendRequest(peer1.PeerID(), "peer_1", "")
+		err := peer2.api.SendFriendRequest(entity.FriendRequest{PeerID: peer1.PeerID(), Alias: "peer_1"})
 		ts.NoError(err)
 
 		ts.Eventually(func() bool {
@@ -219,6 +240,39 @@ func TestCLI_PeersAdd(t *testing.T) {
 		out, err := runCLI(ts, peer1, "peers", "add", "--pid", peer2.PeerID(), "--name", "peer_2")
 		require.NoError(t, err)
 		require.Equal(t, "user added to friends list successfully\n", out)
+
+		pcfg, err := peer1.api.KnownPeerConfig(peer2.PeerID())
+		require.NoError(t, err)
+		require.False(t, pcfg.WeAllowUsingAsExitNode)
+	})
+
+	t.Run("AcceptRequestAllowingExitNode", func(t *testing.T) {
+		ts := NewTestSuite(t)
+		peer1 := ts.NewTestPeer(false)
+		peer2 := ts.NewTestPeer(false)
+		ts.ensurePeersAvailableInDHT(peer1, peer2)
+
+		err := peer2.api.SendFriendRequest(entity.FriendRequest{PeerID: peer1.PeerID(), Alias: "peer_1"})
+		ts.NoError(err)
+
+		ts.Eventually(func() bool {
+			reqs, err := peer1.api.AuthRequests()
+			return err == nil && len(reqs) == 1
+		}, 15*time.Second, 50*time.Millisecond)
+
+		out, err := runCLI(ts, peer1, "peers", "add", "--pid", peer2.PeerID(), "--name", "peer_2", "--allow-exit-node")
+		require.NoError(t, err)
+		require.Equal(t, "user added to friends list successfully\n", out)
+
+		pcfg, err := peer1.api.KnownPeerConfig(peer2.PeerID())
+		require.NoError(t, err)
+		require.True(t, pcfg.WeAllowUsingAsExitNode)
+
+		// The permission reaches peer2 through the regular status exchange.
+		ts.Eventually(func() bool {
+			peer1OnPeer2, err := peer2.api.KnownPeerConfig(peer1.PeerID())
+			return err == nil && peer1OnPeer2.AllowedUsingAsExitNode
+		}, 15*time.Second, 100*time.Millisecond)
 	})
 }
 

--- a/cli_test.go
+++ b/cli_test.go
@@ -248,7 +248,7 @@ func TestCLI_PeersAdd(t *testing.T) {
 
 		out, err := runCLI(ts, peer1, "peers", "add", "--pid", peer2.PeerID(), "--name", "peer_2")
 		require.NoError(t, err)
-		require.Equal(t, "user added to friends list successfully\n", out)
+		require.Equal(t, "successfully accepted existing invitation from the device 'peer_2'\n", out)
 
 		pcfg, err := peer1.api.KnownPeerConfig(peer2.PeerID())
 		require.NoError(t, err)
@@ -271,7 +271,7 @@ func TestCLI_PeersAdd(t *testing.T) {
 
 		out, err := runCLI(ts, peer1, "peers", "add", "--pid", peer2.PeerID(), "--name", "peer_2", "--allow-exit-node")
 		require.NoError(t, err)
-		require.Equal(t, "user added to friends list successfully\n", out)
+		require.Equal(t, "successfully accepted existing invitation from the device 'peer_2'\n", out)
 
 		pcfg, err := peer1.api.KnownPeerConfig(peer2.PeerID())
 		require.NoError(t, err)
@@ -283,6 +283,241 @@ func TestCLI_PeersAdd(t *testing.T) {
 			return err == nil && peer1OnPeer2.AllowedUsingAsExitNode
 		}, 15*time.Second, 100*time.Millisecond)
 	})
+}
+
+// TestCLI_PeersInvite covers the invite link lifecycle through the CLI alone,
+// on a single peer: creating links, listing them, revoking one. Redeeming a
+// link takes two nodes and lives in TestCLI_AddPeerViaInviteLink.
+func TestCLI_PeersInvite(t *testing.T) {
+	ts := NewTestSuite(t)
+	peer1 := ts.NewTestPeer(false)
+	ts.NoError(peer1.api.UpdateMySettings("alice"))
+
+	t.Run("Empty", func(t *testing.T) {
+		out, err := runCLI(ts, peer1, "peers", "invite", "list")
+		require.NoError(t, err)
+		require.Equal(t, "you have no invite links\n", out)
+	})
+
+	var createdID string
+
+	t.Run("Create", func(t *testing.T) {
+		out, err := runCLI(ts, peer1, "peers", "invite", "create",
+			"--alias", "laptop", "--label", "my laptop", "--allow-exit-node")
+		require.NoError(t, err)
+
+		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+		require.Greater(t, len(lines), 2, "the link, its summary, and a QR code block")
+
+		// The link comes first and alone on its line, so it can be picked out of
+		// the output by eye or by a script.
+		link, err := entity.ParseInviteLink(lines[0])
+		require.NoError(t, err)
+		require.Equal(t, peer1.PeerID(), link.PeerID)
+		require.Equal(t, "alice", link.Name)
+		require.NotEmpty(t, link.Token, "a created invite is a capability, unlike the link from `me id`")
+
+		summary := lines[1]
+		require.Contains(t, summary, "uses 0/1")
+		require.Contains(t, summary, `alias "laptop"`)
+		require.Contains(t, summary, "exit node")
+		require.NotContains(t, summary, link.Token)
+
+		invites, err := peer1.api.Invites()
+		require.NoError(t, err)
+		require.Len(t, invites, 1)
+		createdID = invites[0].ID
+		require.Contains(t, summary, "id "+createdID)
+	})
+
+	t.Run("CreateWithoutQR", func(t *testing.T) {
+		out, err := runCLI(ts, peer1, "peers", "invite", "create", "--no-qr", "--expires", "never")
+		require.NoError(t, err)
+
+		lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+		require.Len(t, lines, 2, "the link and its summary, nothing else")
+		require.Contains(t, lines[1], "expires never")
+
+		_, err = entity.ParseInviteLink(lines[0])
+		require.NoError(t, err)
+	})
+
+	// Days are ours: time.ParseDuration knows no unit above an hour, and a link
+	// that lives a week is an ordinary thing to ask for.
+	t.Run("CreateExpiringInDays", func(t *testing.T) {
+		out, err := runCLI(ts, peer1, "peers", "invite", "create", "--no-qr", "--expires", "7d", "--uses", "5")
+		require.NoError(t, err)
+		require.Contains(t, out, "uses 0/5")
+
+		invites, err := peer1.api.Invites()
+		require.NoError(t, err)
+		require.WithinDuration(t, time.Now().Add(7*24*time.Hour), invites[0].ExpiresAt, time.Minute)
+	})
+
+	t.Run("List", func(t *testing.T) {
+		out, err := runCLI(ts, peer1, "peers", "invite", "list")
+		require.NoError(t, err)
+
+		require.Contains(t, out, createdID)
+		require.Contains(t, out, "my laptop")
+		require.Contains(t, out, "0/1")
+		require.Contains(t, out, "active")
+		require.Contains(t, out, "never")
+
+		invites, err := peer1.api.Invites()
+		require.NoError(t, err)
+		for _, invite := range invites {
+			link, err := entity.ParseInviteLink(invite.Link)
+			require.NoError(t, err)
+			require.NotContains(t, out, link.Token, "the list must not hand out secrets by default")
+		}
+	})
+
+	t.Run("ListWithLinks", func(t *testing.T) {
+		out, err := runCLI(ts, peer1, "peers", "invite", "list", "--show-links")
+		require.NoError(t, err)
+
+		invites, err := peer1.api.Invites()
+		require.NoError(t, err)
+		for _, invite := range invites {
+			require.Contains(t, out, invite.Link)
+		}
+	})
+
+	t.Run("Revoke", func(t *testing.T) {
+		out, err := runCLI(ts, peer1, "peers", "invite", "revoke", "--id", createdID)
+		require.NoError(t, err)
+		require.Contains(t, out, "peers already added through it stay")
+
+		invites, err := peer1.api.Invites()
+		require.NoError(t, err)
+		for _, invite := range invites {
+			if invite.ID == createdID {
+				require.True(t, invite.Revoked)
+				require.Equal(t, entity.InviteStatusRevoked, invite.Status)
+			}
+		}
+
+		out, err = runCLI(ts, peer1, "peers", "invite", "list")
+		require.NoError(t, err)
+		require.Contains(t, out, "revoked", "a revoked invite stays in the list as history")
+	})
+
+	t.Run("RevokeUnknown", func(t *testing.T) {
+		_, err := runCLI(ts, peer1, "peers", "invite", "revoke", "--id", "0000")
+		require.ErrorContains(t, err, "invite not found")
+	})
+
+	t.Run("AliasWithMultiUse", func(t *testing.T) {
+		_, err := runCLI(ts, peer1, "peers", "invite", "create", "--uses", "5", "--alias", "laptop")
+		require.ErrorContains(t, err, "single-use")
+	})
+
+	// Rejected before any request is made, so the message has to say what a
+	// valid value looks like.
+	t.Run("BadExpires", func(t *testing.T) {
+		_, err := runCLI(ts, peer1, "peers", "invite", "create", "--expires", "tomorrow")
+		require.ErrorContains(t, err, "invalid expires value")
+		require.ErrorContains(t, err, "never")
+	})
+}
+
+// TestCLI_AddPeerViaInviteLink is the whole point of the CLI half of the
+// feature: creating a link on one node and joining by it on another, without
+// touching anything but the command line — and without an accept step.
+func TestCLI_AddPeerViaInviteLink(t *testing.T) {
+	ts := NewTestSuite(t)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(peer1, peer2)
+	ts.NoError(peer1.api.UpdateMySettings("alice"))
+
+	out, err := runCLI(ts, peer1, "peers", "invite", "create", "--no-qr",
+		"--alias", "laptop", "--allow-exit-node")
+	require.NoError(t, err)
+	inviteLink, _, _ := strings.Cut(out, "\n")
+
+	// No --name: the link carries one, and that is the point of it.
+	out, err = runCLI(ts, peer2, "peers", "add", "--link", inviteLink)
+	require.NoError(t, err)
+	require.Contains(t, out, "accepts it automatically")
+
+	ts.Eventually(func() bool {
+		pcfg, err := peer2.api.KnownPeerConfig(peer1.PeerID())
+		return err == nil && pcfg.Confirmed
+	}, 15*time.Second, 50*time.Millisecond)
+
+	require.Len(t, peer1.app.AuthStatus.GetIngoingAuthRequests(), 0, "nobody had to accept anything")
+
+	peer2OnPeer1, err := peer1.api.KnownPeerConfig(peer2.PeerID())
+	require.NoError(t, err)
+	require.Equal(t, "laptop", peer2OnPeer1.Alias, "the alias comes from the invite")
+	require.True(t, peer2OnPeer1.WeAllowUsingAsExitNode)
+
+	peer1OnPeer2, err := peer2.api.KnownPeerConfig(peer1.PeerID())
+	require.NoError(t, err)
+	require.Equal(t, "alice", peer1OnPeer2.Alias, "the name in the link is what we call the creator")
+
+	out, err = runCLI(ts, peer1, "peers", "invite", "list")
+	require.NoError(t, err)
+	require.Contains(t, out, "1/1")
+	require.Contains(t, out, entity.InviteStatusUsedUp)
+}
+
+// TestCLI_PeersAddLinkErrors: the flags of `peers add` stopped being required
+// when --link arrived, so the combinations it accepts are now checked by hand.
+func TestCLI_PeersAddLinkErrors(t *testing.T) {
+	ts := NewTestSuite(t)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+
+	link := entity.BuildInviteLink(peer2.PeerID(), "", "")
+
+	t.Run("LinkAndPeerID", func(t *testing.T) {
+		_, err := runCLI(ts, peer1, "peers", "add", "--link", link, "--pid", peer2.PeerID(), "--name", "peer_2")
+		require.ErrorContains(t, err, "mutually exclusive")
+	})
+
+	t.Run("Neither", func(t *testing.T) {
+		_, err := runCLI(ts, peer1, "peers", "add", "--name", "peer_2")
+		require.ErrorContains(t, err, "either link or pid flag is required")
+	})
+
+	t.Run("NoName", func(t *testing.T) {
+		// A link that carries no name — the token-less form printed by `me id`
+		// for a peer that has not named itself.
+		_, err := runCLI(ts, peer1, "peers", "add", "--link", link)
+		require.ErrorContains(t, err, "name flag is required")
+	})
+
+	t.Run("BrokenLink", func(t *testing.T) {
+		_, err := runCLI(ts, peer1, "peers", "add", "--link", "awl://invite?p=nonsense", "--name", "peer_2")
+		require.ErrorContains(t, err, "invalid peer id")
+	})
+}
+
+// TestCLI_PeersAddByTokenlessLink: a link without a token is not an invitation,
+// it is the shareable form of a peer id — the add stays as manual as ever.
+func TestCLI_PeersAddByTokenlessLink(t *testing.T) {
+	ts := NewTestSuite(t)
+	peer1 := ts.NewTestPeer(false)
+	peer2 := ts.NewTestPeer(false)
+	ts.ensurePeersAvailableInDHT(peer1, peer2)
+
+	link := entity.BuildInviteLink(peer2.PeerID(), "", "peer_2")
+
+	out, err := runCLI(ts, peer1, "peers", "add", "--link", link)
+	require.NoError(t, err)
+	require.Equal(t, "friend request sent successfully\n", out, "no token, no promise of an automatic accept")
+
+	pcfg, err := peer1.api.KnownPeerConfig(peer2.PeerID())
+	require.NoError(t, err)
+	require.Equal(t, "peer_2", pcfg.Alias)
+
+	ts.Eventually(func() bool {
+		reqs, err := peer2.api.AuthRequests()
+		return err == nil && len(reqs) == 1
+	}, 15*time.Second, 50*time.Millisecond)
 }
 
 // TestCLI_PeersRename covers rename by peer ID and by alias on a shared peer pair.

--- a/cli_test.go
+++ b/cli_test.go
@@ -56,10 +56,19 @@ func TestCLI_Me(t *testing.T) {
 	t.Run("Id", func(t *testing.T) {
 		out, err := runCLI(ts, peer1, "me", "id")
 		require.NoError(t, err)
-		lines := strings.SplitN(strings.TrimRight(out, "\n"), "\n", 2)
-		require.Len(t, lines, 2)
+		lines := strings.SplitN(strings.TrimRight(out, "\n"), "\n", 3)
+		require.Len(t, lines, 3)
 		require.Equal(t, fmt.Sprintf("your peer id: %s", peer1.PeerID()), lines[0])
-		require.NotEmpty(t, lines[1]) // QR code block follows
+
+		// The link is the shareable form of the same thing: it carries our name
+		// and grants nothing, so it is safe to show next to the peer id.
+		rawLink := strings.TrimSpace(strings.TrimPrefix(lines[1], "your link:"))
+		link, err := entity.ParseInviteLink(rawLink)
+		require.NoError(t, err)
+		require.Equal(t, peer1.PeerID(), link.PeerID)
+		require.Empty(t, link.Token, "`me id` must never print a token")
+
+		require.NotEmpty(t, lines[2]) // QR code block follows
 	})
 
 	t.Run("ListProxies_Empty", func(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,7 @@ type (
 		DNS                   DNSConfig              `json:"dns"`
 		KnownPeers            map[string]KnownPeer   `json:"knownPeers"`
 		BlockedPeers          map[string]BlockedPeer `json:"blockedPeers"`
+		Invites               map[string]Invite      `json:"invites"`
 		Update                UpdateConfig           `json:"update"`
 	}
 	P2pNodeConfig struct {
@@ -165,6 +166,39 @@ type (
 		// (also from status) it determines whether this peer is currently a valid
 		// VPN gateway target for us — see KnownPeer.CanUseAsVPNGateway.
 		RemoteVPNGatewayServerEnabled bool `json:"remoteVPNGatewayServerEnabled"`
+		// InviteID marks a peer we let in through one of our invite links
+		// (Config.Invites). Non-secret, kept forever: it is what lets the UI say
+		// "added via invite X".
+		InviteID string `json:"inviteID,omitempty"`
+		// PendingInviteToken is the secret from an invite link we are redeeming:
+		// we present it in every auth request until the peer confirms us, then it
+		// is dropped. Set only on the side that used the link.
+		PendingInviteToken string `json:"pendingInviteToken,omitempty"`
+	}
+	// Invite is a link we handed out: whoever presents Token is added
+	// automatically, with the settings stored here, until the invite is used up,
+	// expires or is revoked. Invites are kept forever, including spent ones, as
+	// history and as the target of KnownPeer.InviteID.
+	Invite struct {
+		// ID is a short non-secret identifier, the key in Config.Invites. UI, CLI
+		// and logs refer to an invite by it so the token stays out of sight.
+		ID string `json:"id"`
+		// Token is the bearer secret embedded in the link. Stored in the clear
+		// because the link has to be displayable again.
+		Token string `json:"token"`
+		// Label is an optional human-readable note.
+		Label string `json:"label,omitempty"`
+		// Alias to give the new peer; single-use invites only, aliases are unique.
+		Alias string `json:"alias,omitempty"`
+		// WeAllowUsingAsExitNode is applied to the new peer's KnownPeer.
+		WeAllowUsingAsExitNode bool `json:"weAllowUsingAsExitNode"`
+		MaxUses                int  `json:"maxUses"`
+		UsedCount              int  `json:"usedCount"`
+		// ExpiresAt is checked against our own clock at redemption time; zero
+		// means the invite never expires.
+		ExpiresAt time.Time `json:"expiresAt"`
+		CreatedAt time.Time `json:"createdAt"`
+		Revoked   bool      `json:"revoked"`
 	}
 	BlockedPeer struct {
 		// Hex-encoded multihash representing a peer ID

--- a/config/invites.go
+++ b/config/invites.go
@@ -1,0 +1,221 @@
+package config
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"sort"
+	"time"
+)
+
+const (
+	// inviteIDBytes is the entropy of the invite ID, hex-encoded into
+	// 2*inviteIDBytes characters. It only has to be unique among our own
+	// invites, not unguessable — the token is the secret — and short enough to
+	// retype into `awl cli peers invite revoke --id`. Collisions are retried,
+	// so this can be raised without touching anything else: no caller assumes a
+	// length.
+	inviteIDBytes = 2
+	// inviteTokenBytes is the entropy of the bearer token. 128 bits makes
+	// brute force pointless (every attempt costs a libp2p connection)
+	inviteTokenBytes = 16
+)
+
+// Reasons an invite cannot be redeemed. They double as the metric label in
+// service.AuthStatus, so they are distinguished rather than folded into one.
+var (
+	ErrInviteNotFound = errors.New("invite not found")
+	ErrInviteRevoked  = errors.New("invite is revoked")
+	ErrInviteExpired  = errors.New("invite has expired")
+	ErrInviteUsedUp   = errors.New("invite has no uses left")
+)
+
+// CreateInviteParams are the caller-chosen fields of a new invite; ID, Token
+// and CreatedAt are generated.
+type CreateInviteParams struct {
+	Label string
+	// Alias for the peer that redeems the invite. Only meaningful for
+	// single-use invites — aliases must be unique.
+	Alias                string
+	AllowUsingAsExitNode bool
+	// MaxUses below 1 is clamped to 1; the API layer bounds the upper end.
+	MaxUses int
+	// ExpiresAt zero means the invite never expires.
+	ExpiresAt time.Time
+}
+
+func (c *Config) CreateInvite(params CreateInviteParams) (Invite, error) {
+	token, err := generateInviteToken()
+	if err != nil {
+		return Invite{}, err
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	id, err := c.generateInviteIDUnlocked()
+	if err != nil {
+		return Invite{}, err
+	}
+
+	// An invite with no uses would be born spent and could never be redeemed,
+	// so a caller that forgot to set MaxUses gets the single-use default rather
+	// than a dead link.
+	if params.MaxUses < 1 {
+		params.MaxUses = 1
+	}
+
+	invite := Invite{
+		ID:                     id,
+		Token:                  token,
+		Label:                  params.Label,
+		Alias:                  params.Alias,
+		WeAllowUsingAsExitNode: params.AllowUsingAsExitNode,
+		MaxUses:                params.MaxUses,
+		ExpiresAt:              params.ExpiresAt,
+		CreatedAt:              time.Now(),
+	}
+	c.Invites[id] = invite
+	c.Save()
+
+	return invite, nil
+}
+
+// ListInvites returns a copy of all invites, spent ones included.
+func (c *Config) ListInvites() []Invite {
+	c.RLock()
+	defer c.RUnlock()
+
+	invites := make([]Invite, 0, len(c.Invites))
+	for _, invite := range c.Invites {
+		invites = append(invites, invite)
+	}
+
+	sort.SliceStable(invites, func(i, j int) bool {
+		return invites[i].CreatedAt.After(invites[j].CreatedAt)
+	})
+
+	return invites
+}
+
+func (c *Config) GetInvite(id string) (Invite, bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	invite, ok := c.Invites[id]
+	return invite, ok
+}
+
+// RevokeInvite closes an invite to new connections. Peers already added through
+// it keep working; revoking is not kicking anyone out.
+func (c *Config) RevokeInvite(id string) bool {
+	c.Lock()
+	defer c.Unlock()
+
+	invite, ok := c.Invites[id]
+	if !ok {
+		return false
+	}
+	if !invite.Revoked {
+		invite.Revoked = true
+		c.Invites[id] = invite
+		c.Save()
+	}
+	return true
+}
+
+// CheckInvite reports whether token matches an invite that can be redeemed
+// right now, consuming nothing. It is a peek, used to decide what to do with an
+// auth request (and to label the rejection metric); the authoritative check is
+// ReserveInviteUnlocked.
+func (c *Config) CheckInvite(token string) (Invite, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.findUsableInviteUnlocked(token, time.Now())
+}
+
+// ReserveInviteUnlocked consumes one use of the invite matching token. The
+// caller must hold the write lock, and must perform the write that redeems the
+// invite — inserting the peer, confirming it — inside the same critical
+// section.
+func (c *Config) ReserveInviteUnlocked(token string) (Invite, error) {
+	invite, err := c.findUsableInviteUnlocked(token, time.Now())
+	if err != nil {
+		return invite, err
+	}
+
+	invite.UsedCount++
+	c.Invites[invite.ID] = invite
+	c.Save()
+
+	return invite, nil
+}
+
+// findUsableInviteUnlocked looks an invite up by its token. Invites number in
+// the tens, so a scan is enough and no token index has to be kept in sync.
+func (c *Config) findUsableInviteUnlocked(token string, now time.Time) (Invite, error) {
+	if token == "" {
+		return Invite{}, ErrInviteNotFound
+	}
+
+	for _, invite := range c.Invites {
+		if invite.Token != token {
+			continue
+		}
+		if err := invite.usable(now); err != nil {
+			return invite, err
+		}
+		return invite, nil
+	}
+
+	return Invite{}, ErrInviteNotFound
+}
+
+// IsExpired reports whether the invite is past its expiry by our own clock.
+// Clock skew between nodes plays no part: only the creator checks this.
+func (i Invite) IsExpired(now time.Time) bool {
+	return !i.ExpiresAt.IsZero() && now.After(i.ExpiresAt)
+}
+
+func (i Invite) IsUsedUp() bool {
+	return i.UsedCount >= i.MaxUses
+}
+
+// usable returns nil if the invite can be redeemed at now, otherwise the reason
+// it cannot.
+func (i Invite) usable(now time.Time) error {
+	switch {
+	case i.Revoked:
+		return ErrInviteRevoked
+	case i.IsExpired(now):
+		return ErrInviteExpired
+	case i.IsUsedUp():
+		return ErrInviteUsedUp
+	}
+	return nil
+}
+
+func generateInviteToken() (string, error) {
+	buf := make([]byte, inviteTokenBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// generateInviteIDUnlocked returns an ID not yet present in Invites; the caller must hold the lock.
+func (c *Config) generateInviteIDUnlocked() (string, error) {
+	buf := make([]byte, inviteIDBytes)
+	for range 10 {
+		if _, err := rand.Read(buf); err != nil {
+			return "", err
+		}
+		id := hex.EncodeToString(buf)
+		if _, exists := c.Invites[id]; !exists {
+			return id, nil
+		}
+	}
+	return "", errors.New("could not generate a unique invite id")
+}

--- a/config/invites_test.go
+++ b/config/invites_test.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateInvite(t *testing.T) {
+	conf, _ := newTestConfig(t)
+
+	invite, err := conf.CreateInvite(CreateInviteParams{
+		Label:                "laptop",
+		Alias:                "my-laptop",
+		AllowUsingAsExitNode: true,
+		MaxUses:              1,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, invite.ID, hex.EncodedLen(inviteIDBytes))
+	assert.NotEmpty(t, invite.Token)
+	assert.NotEqual(t, invite.ID, invite.Token)
+	assert.True(t, invite.ExpiresAt.IsZero())
+	assert.False(t, invite.CreatedAt.IsZero())
+
+	stored, ok := conf.GetInvite(invite.ID)
+	require.True(t, ok)
+	assert.Equal(t, invite, stored)
+
+	second, err := conf.CreateInvite(CreateInviteParams{MaxUses: 1})
+	require.NoError(t, err)
+	assert.NotEqual(t, invite.ID, second.ID)
+	assert.NotEqual(t, invite.Token, second.Token)
+	assert.Len(t, conf.ListInvites(), 2)
+
+	// A caller that forgets MaxUses must not get an invite that is born spent.
+	withoutUses, err := conf.CreateInvite(CreateInviteParams{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, withoutUses.MaxUses)
+	assert.False(t, withoutUses.IsUsedUp())
+}
+
+// TestInviteJSONTags pins the on-disk names of the invite fields. They are a
+// compatibility boundary: renaming a tag silently drops invites (or a
+// redeemer's token) from an existing config instead of failing loudly.
+func TestInviteJSONTags(t *testing.T) {
+	conf, _ := newTestConfig(t)
+	invite, err := conf.CreateInvite(CreateInviteParams{MaxUses: 1, Alias: "laptop"})
+	require.NoError(t, err)
+	// Under the lock, and read back through Export: the writer goroutine
+	// marshals the same config concurrently.
+	conf.Lock()
+	conf.KnownPeers["peer-1"] = KnownPeer{
+		PeerID:             "peer-1",
+		InviteID:           invite.ID,
+		PendingInviteToken: "s3cret-token",
+	}
+	conf.Unlock()
+
+	data := conf.Export()
+	for _, key := range []string{`"invites"`, `"pendingInviteToken"`, `"inviteID"`, `"maxUses"`, `"usedCount"`, `"expiresAt"`} {
+		assert.True(t, strings.Contains(string(data), key), "config JSON is missing %s", key)
+	}
+
+	restored := &Config{}
+	require.NoError(t, json.Unmarshal(data, restored))
+	restoredInvite := restored.Invites[invite.ID]
+	assert.Equal(t, invite.Token, restoredInvite.Token)
+	assert.Equal(t, invite.Alias, restoredInvite.Alias)
+	assert.Equal(t, invite.MaxUses, restoredInvite.MaxUses)
+	// Times survive as RFC 3339, so compare instants, not struct internals.
+	assert.True(t, invite.CreatedAt.Equal(restoredInvite.CreatedAt))
+	assert.Equal(t, "s3cret-token", restored.KnownPeers["peer-1"].PendingInviteToken)
+	assert.Equal(t, invite.ID, restored.KnownPeers["peer-1"].InviteID)
+}
+
+// reserveInvite takes the write lock the way the real callers do — inside the
+// critical section that also writes the peer the invite is being spent on.
+func reserveInvite(t *testing.T, conf *Config, token string) (Invite, error) {
+	t.Helper()
+
+	conf.Lock()
+	defer conf.Unlock()
+
+	return conf.ReserveInviteUnlocked(token)
+}
+
+func TestReserveInvite(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		conf, _ := newTestConfig(t)
+		created, err := conf.CreateInvite(CreateInviteParams{MaxUses: 1, Alias: "laptop"})
+		require.NoError(t, err)
+
+		reserved, err := reserveInvite(t, conf, created.Token)
+		require.NoError(t, err)
+		assert.Equal(t, created.ID, reserved.ID)
+		assert.Equal(t, "laptop", reserved.Alias)
+
+		stored, _ := conf.GetInvite(created.ID)
+		assert.Equal(t, 1, stored.UsedCount)
+
+		// single-use: the second attempt finds nothing left
+		_, err = reserveInvite(t, conf, created.Token)
+		assert.ErrorIs(t, err, ErrInviteUsedUp)
+	})
+
+	t.Run("MultiUse", func(t *testing.T) {
+		conf, _ := newTestConfig(t)
+		created, err := conf.CreateInvite(CreateInviteParams{MaxUses: 3})
+		require.NoError(t, err)
+
+		for range 3 {
+			_, err = reserveInvite(t, conf, created.Token)
+			require.NoError(t, err)
+		}
+		_, err = reserveInvite(t, conf, created.Token)
+		assert.ErrorIs(t, err, ErrInviteUsedUp)
+	})
+
+	t.Run("Expired", func(t *testing.T) {
+		conf, _ := newTestConfig(t)
+		created, err := conf.CreateInvite(CreateInviteParams{
+			MaxUses:   1,
+			ExpiresAt: time.Now().Add(-time.Minute),
+		})
+		require.NoError(t, err)
+
+		_, err = reserveInvite(t, conf, created.Token)
+		assert.ErrorIs(t, err, ErrInviteExpired)
+
+		stored, _ := conf.GetInvite(created.ID)
+		assert.Equal(t, 0, stored.UsedCount, "a rejected invite must not be consumed")
+	})
+
+	t.Run("Revoked", func(t *testing.T) {
+		conf, _ := newTestConfig(t)
+		created, err := conf.CreateInvite(CreateInviteParams{MaxUses: 5})
+		require.NoError(t, err)
+		require.True(t, conf.RevokeInvite(created.ID))
+
+		_, err = reserveInvite(t, conf, created.Token)
+		assert.ErrorIs(t, err, ErrInviteRevoked)
+
+		assert.False(t, conf.RevokeInvite("no-such-invite"))
+	})
+
+	t.Run("UnknownToken", func(t *testing.T) {
+		conf, _ := newTestConfig(t)
+		_, err := conf.CreateInvite(CreateInviteParams{MaxUses: 1})
+		require.NoError(t, err)
+
+		_, err = reserveInvite(t, conf, "not-a-real-token")
+		assert.ErrorIs(t, err, ErrInviteNotFound)
+
+		_, err = reserveInvite(t, conf, "")
+		assert.ErrorIs(t, err, ErrInviteNotFound)
+	})
+}
+
+// TestCheckInvite: the peek answers the same questions as the reservation but
+// spends nothing — the auth handler uses it to pick a branch before it knows
+// whether a peer will actually be added.
+func TestCheckInvite(t *testing.T) {
+	conf, _ := newTestConfig(t)
+	created, err := conf.CreateInvite(CreateInviteParams{MaxUses: 1, Alias: "laptop"})
+	require.NoError(t, err)
+
+	checked, err := conf.CheckInvite(created.Token)
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, checked.ID)
+
+	stored, _ := conf.GetInvite(created.ID)
+	assert.Equal(t, 0, stored.UsedCount, "checking must not consume a use")
+
+	_, err = conf.CheckInvite("not-a-real-token")
+	assert.ErrorIs(t, err, ErrInviteNotFound)
+
+	_, err = reserveInvite(t, conf, created.Token)
+	require.NoError(t, err)
+	_, err = conf.CheckInvite(created.Token)
+	assert.ErrorIs(t, err, ErrInviteUsedUp)
+}
+
+// TestSetDefaultsInitsInvites covers configs written before invites existed:
+// the map is nil there, and writing into a nil map panics.
+func TestSetDefaultsInitsInvites(t *testing.T) {
+	conf := &Config{dataDir: t.TempDir()}
+	setDefaults(conf, nil)
+
+	require.NotNil(t, conf.Invites)
+	assert.Empty(t, conf.Invites)
+}

--- a/config/other.go
+++ b/config/other.go
@@ -300,6 +300,10 @@ func setDefaults(conf *Config, bus awlevent.Bus) {
 		conf.BlockedPeers = make(map[string]BlockedPeer)
 	}
 
+	if conf.Invites == nil {
+		conf.Invites = make(map[string]Invite)
+	}
+
 	if conf.dataDir == "" {
 		conf.dataDir = CalcAppDataDir()
 	}

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -276,6 +276,9 @@ definitions:
     properties:
       alias:
         type: string
+      allowUsingAsExitNode:
+        description: 'optional: allow the peer to use us as an exit node'
+        type: boolean
       ipaddr:
         description: 'optional: specific IP address for the peer'
         type: string
@@ -289,6 +292,9 @@ definitions:
     properties:
       alias:
         type: string
+      allowUsingAsExitNode:
+        description: 'optional: allow the peer to use us as an exit node'
+        type: boolean
       decline:
         type: boolean
       ipaddr:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -42,6 +42,42 @@ definitions:
       username:
         type: string
     type: object
+  config.Invite:
+    properties:
+      alias:
+        description: Alias to give the new peer; single-use invites only, aliases
+          are unique.
+        type: string
+      createdAt:
+        type: string
+      expiresAt:
+        description: |-
+          ExpiresAt is checked against our own clock at redemption time; zero
+          means the invite never expires.
+        type: string
+      id:
+        description: |-
+          ID is a short non-secret identifier, the key in Config.Invites. UI, CLI
+          and logs refer to an invite by it so the token stays out of sight.
+        type: string
+      label:
+        description: Label is an optional human-readable note.
+        type: string
+      maxUses:
+        type: integer
+      revoked:
+        type: boolean
+      token:
+        description: |-
+          Token is the bearer secret embedded in the link. Stored in the clear
+          because the link has to be displayable again.
+        type: string
+      usedCount:
+        type: integer
+      weAllowUsingAsExitNode:
+        description: WeAllowUsingAsExitNode is applied to the new peer's KnownPeer.
+        type: boolean
+    type: object
   config.KnownPeer:
     properties:
       alias:
@@ -61,8 +97,17 @@ definitions:
       domainName:
         description: DomainName without zone suffix (.awl)
         type: string
+      inviteID:
+        description: |-
+          InviteID marks a peer we let in through one of our invite links
+          (Config.Invites). Non-secret, kept forever: it is what lets the UI say
+          "added via invite X".
+        type: string
       ipAddr:
         description: IPAddr used for forwarding
+        type: string
+      ipAddrV6:
+        description: IPAddrV6 used for IPv6 overlay forwarding (derived from peerID)
         type: string
       lastSeen:
         description: Time of last connection
@@ -72,6 +117,12 @@ definitions:
         type: string
       peerId:
         description: Hex-encoded multihash representing a peer ID
+        type: string
+      pendingInviteToken:
+        description: |-
+          PendingInviteToken is the secret from an invite link we are redeeming:
+          we present it in every auth request until the peer confirms us, then it
+          is dropped. Set only on the side that used the link.
         type: string
       remoteVPNGatewayServerEnabled:
         description: |-
@@ -151,6 +202,8 @@ definitions:
         type: string
       ipNet:
         type: string
+      ipNetV6:
+        type: string
     type: object
   config.VPNGatewayConfig:
     properties:
@@ -228,6 +281,33 @@ definitions:
         format: int64
         type: integer
     type: object
+  entity.CreateInviteRequest:
+    properties:
+      alias:
+        description: Alias to give the peer that redeems the link. Single-use links
+          only.
+        maxLength: 100
+        type: string
+      allowUsingAsExitNode:
+        description: AllowUsingAsExitNode lets the new peer use us as an exit node.
+        type: boolean
+      expiresInSeconds:
+        description: |-
+          ExpiresInSeconds: 0 means the invite never expires. A number rather
+          than a duration string, as with ReconnectionIntervalSec; clients parse
+          "24h" on their side. Maximum is 365 days.
+        maximum: 31536000
+        minimum: 0
+        type: integer
+      label:
+        maxLength: 100
+        type: string
+      maxUses:
+        description: 'MaxUses: 0 means the default, 1 (single-use).'
+        maximum: 100
+        minimum: 0
+        type: integer
+    type: object
   entity.DhtDebugInfo:
     properties:
       bootstrapPeers:
@@ -284,6 +364,12 @@ definitions:
         type: string
       peerID:
         type: string
+      token:
+        description: |-
+          optional: token from an invite link (see InviteLink.Token). It is
+          stored with the peer and presented in every auth request until the
+          peer confirms us, which it then does without a manual accept.
+        type: string
     required:
     - alias
     - peerID
@@ -313,6 +399,42 @@ definitions:
       version:
         type: string
     type: object
+  entity.InviteResponse:
+    properties:
+      alias:
+        type: string
+      allowUsingAsExitNode:
+        type: boolean
+      createdAt:
+        type: string
+      expiresAt:
+        description: ExpiresAt zero means the invite never expires.
+        type: string
+      id:
+        type: string
+      label:
+        type: string
+      link:
+        description: |-
+          Link is rebuilt on every request from the current node name, so
+          renaming this node changes the link shown here while links already
+          handed out keep working — the name plays no part in validation.
+        type: string
+      maxUses:
+        type: integer
+      revoked:
+        type: boolean
+      status:
+        description: Status is derived from the fields above for display.
+        enum:
+          - active
+          - expired
+          - used_up
+          - revoked
+        type: string
+      usedCount:
+        type: integer
+    type: object
   entity.KnownPeersResponse:
     properties:
       alias:
@@ -334,7 +456,14 @@ definitions:
         type: string
       domainName:
         type: string
+      inviteID:
+        description: |-
+          InviteID is set when we let this peer in through one of our invite
+          links; empty otherwise. Non-secret, see config.KnownPeer.InviteID.
+        type: string
       ipAddr:
+        type: string
+      ipAddrV6:
         type: string
       lastSeen:
         type: string
@@ -426,6 +555,13 @@ definitions:
         $ref: '#/definitions/entity.VPNInfo'
       vpngateway:
         $ref: '#/definitions/entity.VPNGatewayInfo'
+    type: object
+  entity.RevokeInviteRequest:
+    properties:
+      id:
+        type: string
+    required:
+      - id
     type: object
   entity.SOCKS5Info:
     properties:
@@ -525,6 +661,8 @@ definitions:
         type: string
       ipnet:
         type: string
+      ipv6Addr:
+        type: string
       vpninterfaceEnabled:
         type: boolean
     type: object
@@ -542,6 +680,10 @@ definitions:
         type: string
       httpListenOnAdminHost:
         type: boolean
+      invites:
+        additionalProperties:
+          $ref: '#/definitions/config.Invite'
+        type: object
       knownPeers:
         additionalProperties:
           $ref: '#/definitions/config.KnownPeer'
@@ -794,6 +936,79 @@ paths:
           schema:
             $ref: '#/definitions/api.Error'
       summary: Invite new peer
+      tags:
+        - Peers
+  /peers/invites/create:
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - description: Params
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/entity.CreateInviteRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/entity.InviteResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Create an invite link
+      tags:
+        - Peers
+  /peers/invites/list:
+    get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/entity.InviteResponse'
+            type: array
+      summary: Get invite links
+      tags:
+        - Peers
+  /peers/invites/revoke:
+    post:
+      consumes:
+        - application/json
+      description: Stops new connections through the link; peers already added stay.
+      parameters:
+        - description: Params
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/entity.RevokeInviteRequest'
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/api.Error'
+      summary: Revoke an invite link
       tags:
       - Peers
   /peers/remove:

--- a/entity/api.go
+++ b/entity/api.go
@@ -18,7 +18,7 @@ type (
 	}
 	FriendRequest struct {
 		PeerID string `validate:"required"`
-		Alias  string `validate:"required,trimmed_str_not_empty"`
+		Alias  string `validate:"required,trimmed_str_not_empty,max=100,no_control_chars"`
 		// optional: specific IP address for the peer
 		IPAddr string `validate:"omitempty,ipv4"`
 		// optional: allow the peer to use us as an exit node
@@ -30,7 +30,7 @@ type (
 	}
 	FriendRequestReply struct {
 		PeerID  string `validate:"required"`
-		Alias   string `validate:"required,trimmed_str_not_empty"`
+		Alias   string `validate:"required,trimmed_str_not_empty,max=100,no_control_chars"`
 		Decline bool
 		// optional: specific IP address for the peer
 		IPAddr string `validate:"omitempty,ipv4"`
@@ -42,14 +42,14 @@ type (
 	}
 	UpdatePeerSettingsRequest struct {
 		PeerID     string `validate:"required"`
-		Alias      string `validate:"required,trimmed_str_not_empty"`
+		Alias      string `validate:"required,trimmed_str_not_empty,max=100,no_control_chars"`
 		DomainName string `validate:"required,trimmed_str_not_empty"`
 		// TODO: support ipv6
 		IPAddr               string `validate:"required,ipv4"`
 		AllowUsingAsExitNode bool
 	}
 	UpdateMySettingsRequest struct {
-		Name string
+		Name string `validate:"max=100,no_control_chars"`
 	}
 
 	UpdateProxySettingsRequest struct {
@@ -64,10 +64,10 @@ type (
 		// "24h" on their side. Maximum is 365 days.
 		ExpiresInSeconds int64 `validate:"gte=0,lte=31536000"`
 		// Alias to give the peer that redeems the link. Single-use links only.
-		Alias string `validate:"max=100"`
+		Alias string `validate:"max=100,no_control_chars"`
 		// AllowUsingAsExitNode lets the new peer use us as an exit node.
 		AllowUsingAsExitNode bool
-		Label                string `validate:"max=100"`
+		Label                string `validate:"max=100,no_control_chars"`
 	}
 	RevokeInviteRequest struct {
 		ID string `validate:"required"`

--- a/entity/api.go
+++ b/entity/api.go
@@ -21,6 +21,8 @@ type (
 		Alias  string `validate:"required,trimmed_str_not_empty"`
 		// optional: specific IP address for the peer
 		IPAddr string `validate:"omitempty,ipv4"`
+		// optional: allow the peer to use us as an exit node
+		AllowUsingAsExitNode bool
 	}
 	FriendRequestReply struct {
 		PeerID  string `validate:"required"`
@@ -28,6 +30,8 @@ type (
 		Decline bool
 		// optional: specific IP address for the peer
 		IPAddr string `validate:"omitempty,ipv4"`
+		// optional: allow the peer to use us as an exit node
+		AllowUsingAsExitNode bool
 	}
 	PeerIDRequest struct {
 		PeerID string `validate:"required"`

--- a/entity/api.go
+++ b/entity/api.go
@@ -23,6 +23,10 @@ type (
 		IPAddr string `validate:"omitempty,ipv4"`
 		// optional: allow the peer to use us as an exit node
 		AllowUsingAsExitNode bool
+		// optional: token from an invite link (see InviteLink.Token). It is
+		// stored with the peer and presented in every auth request until the
+		// peer confirms us, which it then does without a manual accept.
+		Token string
 	}
 	FriendRequestReply struct {
 		PeerID  string `validate:"required"`
@@ -51,6 +55,23 @@ type (
 	UpdateProxySettingsRequest struct {
 		UsingPeerID string
 	}
+
+	CreateInviteRequest struct {
+		// MaxUses: 0 means the default, 1 (single-use).
+		MaxUses int `validate:"gte=0,lte=100"`
+		// ExpiresInSeconds: 0 means the invite never expires. A number rather
+		// than a duration string, as with ReconnectionIntervalSec; clients parse
+		// "24h" on their side. Maximum is 365 days.
+		ExpiresInSeconds int64 `validate:"gte=0,lte=31536000"`
+		// Alias to give the peer that redeems the link. Single-use links only.
+		Alias string `validate:"max=100"`
+		// AllowUsingAsExitNode lets the new peer use us as an exit node.
+		AllowUsingAsExitNode bool
+		Label                string `validate:"max=100"`
+	}
+	RevokeInviteRequest struct {
+		ID string `validate:"required"`
+	}
 )
 
 // Responses
@@ -70,11 +91,14 @@ type (
 		WeAllowUsingAsExitNode        bool
 		AllowedUsingAsExitNode        bool
 		RemoteVPNGatewayServerEnabled bool
-		LastSeen                      time.Time
-		Connections                   []p2p.ConnectionInfo
-		NetworkStats                  metrics.Stats
-		NetworkStatsInIECUnits        StatsInUnits
-		Ping                          time.Duration `swaggertype:"primitive,integer"`
+		// InviteID is set when we let this peer in through one of our invite
+		// links; empty otherwise. Non-secret, see config.KnownPeer.InviteID.
+		InviteID               string
+		LastSeen               time.Time
+		Connections            []p2p.ConnectionInfo
+		NetworkStats           metrics.Stats
+		NetworkStatsInIECUnits StatsInUnits
+		Ping                   time.Duration `swaggertype:"primitive,integer"`
 	}
 
 	PeerInfo struct {
@@ -128,6 +152,27 @@ type (
 		SuggestedIP string
 	}
 
+	// InviteResponse describes one invite link. The token is never returned on
+	// its own — only inside Link, which is what the user shares.
+	InviteResponse struct {
+		ID    string
+		Label string
+		// Link is rebuilt on every request from the current node name, so
+		// renaming this node changes the link shown here while links already
+		// handed out keep working — the name plays no part in validation.
+		Link                 string
+		Alias                string
+		AllowUsingAsExitNode bool
+		MaxUses              int
+		UsedCount            int
+		// ExpiresAt zero means the invite never expires.
+		ExpiresAt time.Time
+		CreatedAt time.Time
+		Revoked   bool
+		// Status is derived from the fields above for display.
+		Status string `enums:"active,expired,used_up,revoked"`
+	}
+
 	ListAvailableProxiesResponse struct {
 		Proxies []AvailableProxy
 	}
@@ -168,6 +213,14 @@ type (
 		PeerName  string
 		Connected bool
 	}
+)
+
+// Values of InviteResponse.Status.
+const (
+	InviteStatusActive  = "active"
+	InviteStatusExpired = "expired"
+	InviteStatusUsedUp  = "used_up"
+	InviteStatusRevoked = "revoked"
 )
 
 type (

--- a/entity/invite_link.go
+++ b/entity/invite_link.go
@@ -1,0 +1,131 @@
+package entity
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Invite link format: awl://invite?p=<peer_id>&t=<token>&n=<name>
+//
+// The peer ID lives in the query, not in the authority, on purpose: it is
+// base58 and therefore case-sensitive, while hosts are historically
+// case-insensitive and get lowercased by messenger linkifiers and Android
+// intent matching, which would break peer.Decode. The authority is the fixed
+// word "invite", leaving room for other awl:// URLs later.
+//
+// The token is optional. With it the link is a capability — whoever presents it
+// is added automatically; without it the link is just "here is me, with a name
+// to fill in", the shareable form of a peer ID. One format covers both so that
+// every consumer — the add form, the QR scanner, the CLI — has a single input
+// to parse.
+//
+// The same format has a second implementation in Dart (awl-flutter), so the
+// format is a contract and both sides carry tests for it.
+const (
+	InviteLinkScheme = "awl"
+	InviteLinkHost   = "invite"
+	// InviteLinkVersion is the newest format we understand. It is never written
+	// into a link: adding a query parameter is backwards compatible on its own
+	// (parsers ignore what they do not know), so a version only has to appear
+	// the day something incompatible changes. Reading it is kept from day one,
+	// so that such a link can be rejected with a comprehensible message instead
+	// of a random parse failure.
+	InviteLinkVersion = 1
+)
+
+// ErrNotInviteLink reports input that is not an awl invite link at all, as
+// opposed to a malformed one. It lets a UI tell "this is a peer ID" from "this
+// link is broken".
+var ErrNotInviteLink = errors.New("not an awl invite link")
+
+// InviteLink is the payload of an invite link: who invites, the bearer token
+// granting automatic acceptance, and how the inviter calls itself.
+type InviteLink struct {
+	PeerID string
+	// Token grants automatic acceptance to whoever presents it. Empty for a
+	// link that only identifies its author, which is then added by hand as usual.
+	Token string
+	// Name is the creator's display name, used to prefill the add form so the
+	// peer can be added before the creator ever comes online. Optional.
+	Name string
+}
+
+// BuildInviteLink renders a link; an empty token or name is left out. The query
+// is assembled by hand rather than through url.Values, which sorts its keys:
+// parameters stay in the p, t, n order the format is written in, so links read
+// the same way everywhere they are shown.
+func BuildInviteLink(peerID, token, name string) string {
+	params := []string{"p=" + url.QueryEscape(peerID)}
+	if token != "" {
+		params = append(params, "t="+url.QueryEscape(token))
+	}
+	if name != "" {
+		params = append(params, "n="+url.QueryEscape(name))
+	}
+
+	link := url.URL{
+		Scheme:   InviteLinkScheme,
+		Host:     InviteLinkHost,
+		RawQuery: strings.Join(params, "&"),
+	}
+	return link.String()
+}
+
+// ParseInviteLink parses a link, tolerating surrounding whitespace and newlines
+// (links get copy-pasted out of messengers).
+func ParseInviteLink(rawLink string) (InviteLink, error) {
+	rawLink = strings.TrimSpace(rawLink)
+	if rawLink == "" {
+		return InviteLink{}, ErrNotInviteLink
+	}
+
+	parsed, err := url.Parse(rawLink)
+	if err != nil {
+		return InviteLink{}, fmt.Errorf("%w: %v", ErrNotInviteLink, err)
+	}
+	if !strings.EqualFold(parsed.Scheme, InviteLinkScheme) {
+		return InviteLink{}, ErrNotInviteLink
+	}
+	if !strings.EqualFold(parsed.Host, InviteLinkHost) {
+		return InviteLink{}, fmt.Errorf("unknown awl link type '%s'", parsed.Host)
+	}
+
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return InviteLink{}, fmt.Errorf("invalid invite link parameters: %v", err)
+	}
+
+	// A missing version means the original format, v1 — which is what every
+	// link we produce is, since we never write the parameter.
+	if rawVersion := query.Get("v"); rawVersion != "" {
+		version, err := strconv.Atoi(rawVersion)
+		if err != nil {
+			return InviteLink{}, fmt.Errorf("invalid invite link version '%s'", rawVersion)
+		}
+		if version > InviteLinkVersion {
+			return InviteLink{}, fmt.Errorf("this invite link was created by a newer version of anywherelan (link version %d, supported %d)",
+				version, InviteLinkVersion)
+		}
+	}
+
+	// Kept exactly as written: base58 peer IDs are case-sensitive.
+	peerID := query.Get("p")
+	if peerID == "" {
+		return InviteLink{}, errors.New("invite link has no peer id")
+	}
+	if _, err := peer.Decode(peerID); err != nil {
+		return InviteLink{}, fmt.Errorf("invite link has an invalid peer id: %v", err)
+	}
+
+	return InviteLink{
+		PeerID: peerID,
+		// Optional: without it the link cannot be redeemed, only added by hand.
+		Token: query.Get("t"),
+		Name:  query.Get("n"),
+	}, nil
+}

--- a/entity/invite_link_test.go
+++ b/entity/invite_link_test.go
@@ -1,0 +1,149 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testPeerID = "12D3KooWGRjpNYgFssihdgTDnr5rdhdh9ruMTbeT41h1fXfGmatZ"
+
+func TestBuildInviteLink(t *testing.T) {
+	link := BuildInviteLink(testPeerID, "Xk9token", "Alice")
+	assert.Equal(t, "awl://invite?p="+testPeerID+"&t=Xk9token&n=Alice", link)
+
+	assert.Equal(t, "awl://invite?p="+testPeerID+"&t=Xk9token",
+		BuildInviteLink(testPeerID, "Xk9token", ""))
+
+	// No version parameter is ever written: it only has to appear the day the
+	// format changes incompatibly.
+	assert.NotContains(t, link, "v=")
+}
+
+// TestBuildInviteLinkWithoutToken: the same format doubles as the shareable
+// form of a peer ID, so that everything reading a link — the add form, the QR
+// scanner, the CLI — has one input to parse and not two.
+func TestBuildInviteLinkWithoutToken(t *testing.T) {
+	link := BuildInviteLink(testPeerID, "", "Alice")
+	assert.Equal(t, "awl://invite?p="+testPeerID+"&n=Alice", link)
+
+	parsed, err := ParseInviteLink(link)
+	require.NoError(t, err)
+	assert.Equal(t, testPeerID, parsed.PeerID)
+	assert.Empty(t, parsed.Token, "no token means the peer is added by hand")
+	assert.Equal(t, "Alice", parsed.Name)
+
+	bare := BuildInviteLink(testPeerID, "", "")
+	assert.Equal(t, "awl://invite?p="+testPeerID, bare)
+	parsed, err = ParseInviteLink(bare)
+	require.NoError(t, err)
+	assert.Equal(t, testPeerID, parsed.PeerID)
+	assert.Empty(t, parsed.Token)
+	assert.Empty(t, parsed.Name)
+}
+
+// TestBuildInviteLinkEscapesName pins the wire form of the only parameter that
+// can need escaping — a peer ID is base58/base32, a token base64url. It is the
+// cross-language half of the format: the Dart implementation has to read back
+// exactly this, a space written as "+" included.
+func TestBuildInviteLinkEscapesName(t *testing.T) {
+	link := BuildInviteLink(testPeerID, "tok", "Alice Smith")
+	assert.Contains(t, link, "n=Alice+Smith")
+
+	parsed, err := ParseInviteLink(link)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice Smith", parsed.Name)
+
+	// A literal plus is escaped, so it cannot come back as a space.
+	link = BuildInviteLink(testPeerID, "tok", "a+b")
+	assert.Contains(t, link, "n=a%2Bb")
+
+	parsed, err = ParseInviteLink(link)
+	require.NoError(t, err)
+	assert.Equal(t, "a+b", parsed.Name)
+}
+
+func TestParseInviteLinkRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		peer  string
+	}{
+		{name: "Alice", token: "Xk9token"},
+		{name: "", token: "with-_dashes"},
+		{name: "имя с пробелом & амперсандом", token: "aGVsbG8gd29ybGQtLQ"},
+	}
+
+	for _, tt := range tests {
+		link := BuildInviteLink(testPeerID, tt.token, tt.name)
+		parsed, err := ParseInviteLink(link)
+		require.NoError(t, err, link)
+		assert.Equal(t, testPeerID, parsed.PeerID)
+		assert.Equal(t, tt.token, parsed.Token)
+		assert.Equal(t, tt.name, parsed.Name)
+	}
+}
+
+// TestParseInviteLinkKeepsPeerIDCase is the regression for why the peer ID sits
+// in the query and not in the authority: base58 is case-sensitive, hosts are
+// not, and a lowercased peer ID no longer decodes.
+func TestParseInviteLinkKeepsPeerIDCase(t *testing.T) {
+	parsed, err := ParseInviteLink(BuildInviteLink(testPeerID, "token", ""))
+	require.NoError(t, err)
+	assert.Equal(t, testPeerID, parsed.PeerID)
+}
+
+func TestParseInviteLinkSurroundingWhitespace(t *testing.T) {
+	link := BuildInviteLink(testPeerID, "token", "Alice")
+	parsed, err := ParseInviteLink("  \n" + link + "\n\t")
+	require.NoError(t, err)
+	assert.Equal(t, testPeerID, parsed.PeerID)
+}
+
+// TestParseInviteLinkVersion: we never write v=, but we keep reading it, so
+// that a link from a future incompatible format is rejected with a
+// comprehensible message rather than a random parse failure.
+func TestParseInviteLinkVersion(t *testing.T) {
+	// A link without v= is the original format — that is every link we build.
+	parsed, err := ParseInviteLink("awl://invite?p=" + testPeerID + "&t=token")
+	require.NoError(t, err)
+	assert.Equal(t, "token", parsed.Token)
+
+	// v=1 stays acceptable: links were handed out with it while the format was
+	// being settled.
+	parsed, err = ParseInviteLink("awl://invite?p=" + testPeerID + "&t=token&v=1")
+	require.NoError(t, err)
+	assert.Equal(t, "token", parsed.Token)
+}
+
+func TestParseInviteLinkErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		link        string
+		errContains string
+		notALink    bool
+	}{
+		{name: "Empty", link: "   ", notALink: true},
+		{name: "Garbage", link: "just some text", notALink: true},
+		{name: "PlainPeerID", link: testPeerID, notALink: true},
+		{name: "OtherScheme", link: "https://invite?p=" + testPeerID + "&t=token", notALink: true},
+		{name: "UnknownHost", link: "awl://peer?p=" + testPeerID + "&t=token", errContains: "unknown awl link type"},
+		{name: "NoPeerID", link: "awl://invite?t=token&v=1", errContains: "no peer id"},
+		{name: "InvalidPeerID", link: "awl://invite?p=not-a-peer-id&t=token&v=1", errContains: "invalid peer id"},
+		{name: "NewerVersion", link: "awl://invite?p=" + testPeerID + "&t=token&v=2", errContains: "newer version of anywherelan"},
+		{name: "BadVersion", link: "awl://invite?p=" + testPeerID + "&t=token&v=abc", errContains: "invalid invite link version"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseInviteLink(tt.link)
+			require.Error(t, err)
+			if tt.notALink {
+				assert.ErrorIs(t, err, ErrNotInviteLink)
+			} else {
+				assert.ErrorContains(t, err, tt.errContains)
+			}
+		})
+	}
+}

--- a/metrics/peers.go
+++ b/metrics/peers.go
@@ -76,6 +76,22 @@ var (
 		Help:      "Total number of status requests received.",
 	})
 
+	InvitesRedeemedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "peers",
+		Name:      "invites_redeemed_total",
+		Help:      "Total number of invite links successfully redeemed by peers.",
+	})
+
+	// InviteTokensRejectedTotal explains why a peer that presented an invite
+	// token still ended up in the manual accept queue.
+	InviteTokensRejectedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: "peers",
+		Name:      "invite_tokens_rejected_total",
+		Help:      "Total number of invite tokens rejected, by reason.",
+	}, []string{"reason"})
+
 	PeersConnectionEventsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "peers",

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -45,6 +45,19 @@ func SendStatus(stream io.Writer, statusInfo PeerStatusInfo) error {
 
 type AuthPeer struct {
 	Name string
+	// Token is the secret from an invite link, presented by the peer that
+	// redeems it. A valid token means the request is accepted automatically.
+	//
+	// Additive and backwards compatible: ReceiveAuth decodes without
+	// DisallowUnknownFields, so an older awl ignores the field and falls back to
+	// a manual accept, and a request from an older awl simply has none.
+	//
+	// The token must not leak outside this handshake: it travels over the
+	// encrypted libp2p transport and AuthStreamHandler clears it before the
+	// request is stored or emitted. entity.AuthRequest embeds this struct, so
+	// the field is always empty there and swagger does not advertise it —
+	// json:"-" is not an option, it would drop the token from the wire too.
+	Token string `json:",omitempty" swaggerignore:"true"`
 }
 
 type AuthPeerResponse struct {

--- a/service/auth_status.go
+++ b/service/auth_status.go
@@ -194,11 +194,7 @@ func (s *AuthStatus) processPeerStatusInfo(peerID string, peerInfo protocol.Peer
 			peer.Declined = true
 		})
 
-		s.conf.Lock()
-		defer s.conf.Unlock()
-		if s.conf.SOCKS5.UsingPeerID == peerID {
-			s.conf.SOCKS5.UsingPeerID = ""
-		}
+		s.clearSelectedExitNode(peerID)
 
 		return
 	}
@@ -223,16 +219,24 @@ func (s *AuthStatus) processPeerStatusInfo(peerID string, peerInfo protocol.Peer
 		allowedUsingAsExitNode = peer.AllowedUsingAsExitNode
 	})
 
+	if !allowedUsingAsExitNode {
+		s.clearSelectedExitNode(peerID)
+	}
+}
+
+// clearSelectedExitNode drops peerID as our SOCKS5 exit node if it is the one
+// currently selected. Called when the peer declines us or revokes the
+// permission: we never select an exit node on the peer's behalf, but we do stop
+// using one that no longer allows it.
+func (s *AuthStatus) clearSelectedExitNode(peerID string) {
 	s.conf.Lock()
 	defer s.conf.Unlock()
 
-	if allowedUsingAsExitNode && s.conf.SOCKS5.UsingPeerID == "" {
-		s.conf.SOCKS5.UsingPeerID = peerID
+	if s.conf.SOCKS5.UsingPeerID != peerID {
+		return
 	}
-
-	if !allowedUsingAsExitNode && s.conf.SOCKS5.UsingPeerID == peerID {
-		s.conf.SOCKS5.UsingPeerID = ""
-	}
+	s.conf.SOCKS5.UsingPeerID = ""
+	s.conf.Save()
 }
 
 func (s *AuthStatus) AuthStreamHandler(stream network.Stream) {

--- a/service/auth_status.go
+++ b/service/auth_status.go
@@ -270,7 +270,12 @@ func (s *AuthStatus) AuthStreamHandler(stream network.Stream) {
 	}
 	if !confirmed && !isBlocked && autoAccept {
 		defer func() {
-			_ = s.AddPeer(context.Background(), remotePeer, authPeer.Name, s.conf.GenUniqPeerAlias(authPeer.Name, ""), true, "")
+			_ = s.AddPeer(context.Background(), AddPeerParams{
+				PeerID:    remotePeer,
+				Name:      authPeer.Name,
+				Alias:     s.conf.GenUniqPeerAlias(authPeer.Name, ""),
+				Confirmed: true,
+			})
 		}()
 	}
 
@@ -330,9 +335,31 @@ func (s *AuthStatus) SendAuthRequest(ctx context.Context, peerID peer.ID, req pr
 	return nil
 }
 
-func (s *AuthStatus) AddPeer(ctx context.Context, peerID peer.ID, name, alias string, confirmed bool, ipAddr string) error {
+// AddPeerParams describes a peer about to be added to KnownPeers. It is a
+// struct rather than a positional argument list because the callers set
+// different subsets of it (an outgoing invite, an accepted request, an
+// auto-accepted one), and because it keeps growing.
+type AddPeerParams struct {
+	PeerID peer.ID
+	// Name is how the peer calls itself; empty when we invite it first and
+	// learn the name later from the status exchange.
+	Name string
+	// Alias is the local name for the peer, chosen by us.
+	Alias string
+	// Confirmed reports whether the peer has already confirmed us, i.e. we are
+	// accepting its request rather than sending our own.
+	Confirmed bool
+	// IPAddr is the VPN address for the peer. Generated when empty.
+	IPAddr string
+	// AllowUsingAsExitNode lets the peer use us as a SOCKS5 / VPN Gateway exit node.
+	// Announced to it by the status exchange, see createPeerInfo.
+	AllowUsingAsExitNode bool
+}
+
+func (s *AuthStatus) AddPeer(ctx context.Context, params AddPeerParams) error {
+	peerID := params.PeerID
 	peerIDStr := peerID.String()
-	alias = strings.TrimSpace(alias)
+	alias := strings.TrimSpace(params.Alias)
 
 	s.conf.RemoveBlockedPeer(peerIDStr)
 
@@ -345,6 +372,7 @@ func (s *AuthStatus) AddPeer(ctx context.Context, peerID peer.ID, name, alias st
 		s.conf.Unlock()
 		return fmt.Errorf("peer name is not unique")
 	}
+	ipAddr := params.IPAddr
 	if ipAddr != "" {
 		if err := s.conf.CheckIPUnique(ipAddr, peerIDStr); err != nil {
 			s.conf.Unlock()
@@ -355,12 +383,13 @@ func (s *AuthStatus) AddPeer(ctx context.Context, peerID peer.ID, name, alias st
 	}
 
 	newPeerConfig := config.KnownPeer{
-		PeerID:    peerIDStr,
-		Name:      name,
-		Alias:     alias,
-		IPAddr:    ipAddr,
-		Confirmed: confirmed,
-		CreatedAt: time.Now(),
+		PeerID:                 peerIDStr,
+		Name:                   params.Name,
+		Alias:                  alias,
+		IPAddr:                 ipAddr,
+		Confirmed:              params.Confirmed,
+		CreatedAt:              time.Now(),
+		WeAllowUsingAsExitNode: params.AllowUsingAsExitNode,
 	}
 	newPeerConfig.DomainName = awldns.TrimDomainName(newPeerConfig.DisplayName())
 	s.conf.UpsertPeerUnlocked(newPeerConfig)
@@ -376,7 +405,7 @@ func (s *AuthStatus) AddPeer(ctx context.Context, peerID peer.ID, name, alias st
 	go func() {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		if !confirmed {
+		if !params.Confirmed {
 			authPeer := protocol.AuthPeer{
 				Name: s.conf.NodeName(),
 			}

--- a/service/auth_status.go
+++ b/service/auth_status.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -27,7 +28,6 @@ const (
 
 type P2p interface {
 	ConnectPeer(ctx context.Context, peerID peer.ID) error
-	PeerID() peer.ID
 	IsConnected(peerID peer.ID) bool
 	NewStream(ctx context.Context, id peer.ID, proto libp2pProtocol.ID) (network.Stream, error)
 	NewStreamMulti(ctx context.Context, id peer.ID, protos ...libp2pProtocol.ID) (network.Stream, error)
@@ -44,10 +44,15 @@ type AuthStatus struct {
 	p2p           P2p
 	conf          *config.Config
 	authsEmitter  awlevent.Emitter
+	inviteEmitter awlevent.Emitter
 }
 
 func NewAuthStatus(p2pService P2p, conf *config.Config, eventbus awlevent.Bus) *AuthStatus {
 	emitter, err := eventbus.Emitter(new(awlevent.ReceivedAuthRequest))
+	if err != nil {
+		panic(err)
+	}
+	inviteEmitter, err := eventbus.Emitter(new(awlevent.InviteRedeemed))
 	if err != nil {
 		panic(err)
 	}
@@ -59,6 +64,7 @@ func NewAuthStatus(p2pService P2p, conf *config.Config, eventbus awlevent.Bus) *
 		p2p:           p2pService,
 		conf:          conf,
 		authsEmitter:  emitter,
+		inviteEmitter: inviteEmitter,
 	}
 	auth.restoreOutgoingAuths()
 	p2pService.SubscribeConnectionEvents(auth.onPeerConnected, auth.onPeerDisconnected)
@@ -151,6 +157,12 @@ func (s *AuthStatus) ExchangeNewStatusInfo(ctx context.Context, remotePeerID pee
 
 func (s *AuthStatus) BlockPeer(peerID peer.ID, name string) {
 	s.conf.UpsertBlockedPeer(peerID.String(), name)
+
+	// Stop retrying our own auth request to a peer we just blocked or removed.
+	s.authsLock.Lock()
+	delete(s.outgoingAuths, peerID)
+	s.authsLock.Unlock()
+
 	go func() {
 		_ = s.ExchangeNewStatusInfo(context.Background(), peerID, config.KnownPeer{})
 	}()
@@ -192,6 +204,7 @@ func (s *AuthStatus) processPeerStatusInfo(peerID string, peerInfo protocol.Peer
 		s.conf.UpdatePeerFields(peerID, func(peer *config.KnownPeer) {
 			peer.LastSeen = time.Now()
 			peer.Declined = true
+			peer.PendingInviteToken = ""
 		})
 
 		s.clearSelectedExitNode(peerID)
@@ -199,12 +212,13 @@ func (s *AuthStatus) processPeerStatusInfo(peerID string, peerInfo protocol.Peer
 		return
 	}
 
-	var allowedUsingAsExitNode bool
 	s.conf.UpdatePeerFields(peerID, func(peer *config.KnownPeer) {
 		peer.LastSeen = time.Now()
 		peer.Name = peerInfo.Name
 		peer.Confirmed = true
 		peer.Declined = false
+		// The invite token has done its job once the peer confirms us
+		peer.PendingInviteToken = ""
 		if peer.DomainName == "" {
 			peer.DomainName = awldns.TrimDomainName(peer.DisplayName())
 		}
@@ -216,10 +230,9 @@ func (s *AuthStatus) processPeerStatusInfo(peerID string, peerInfo protocol.Peer
 		}
 		peer.AllowedUsingAsExitNode = peerInfo.AllowUsingAsExitNode
 		peer.RemoteVPNGatewayServerEnabled = peerInfo.VPNGatewayServerEnabled
-		allowedUsingAsExitNode = peer.AllowedUsingAsExitNode
 	})
 
-	if !allowedUsingAsExitNode {
+	if !peerInfo.AllowUsingAsExitNode {
 		s.clearSelectedExitNode(peerID)
 	}
 }
@@ -253,13 +266,37 @@ func (s *AuthStatus) AuthStreamHandler(stream network.Stream) {
 		return
 	}
 
+	// The invite token is a bearer secret: it is consumed here and dropped, so
+	// that it is never stored in ingoingAuths, emitted, or returned by API.
+	inviteToken := authPeer.Token
+	authPeer.Token = ""
+
 	_, isBlocked := s.conf.GetBlockedPeer(peerID)
-	_, confirmed := s.conf.GetPeer(peerID)
+	_, known := s.conf.GetPeer(peerID)
 	s.conf.RLock()
 	autoAccept := s.conf.P2pNode.AutoAcceptAuthRequests
 	s.conf.RUnlock()
 
-	if !confirmed && !isBlocked && !autoAccept {
+	// An invite only ever lets a new peer in.
+	// A peer already in KnownPeers is kept as is, we don't apply settings from the invite to it.
+	// Blocking outranks an invite.
+	var (
+		invite      config.Invite
+		inviteValid bool
+	)
+	if !isBlocked && !known {
+		invite, inviteValid = s.checkInvite(inviteToken, peerID)
+	}
+
+	if !isBlocked && !known && (inviteValid || autoAccept) {
+		// A false here means the add lost a race for the invite.
+		known = s.addPeerFromAuth(remotePeer, authPeer, invite, inviteValid)
+	}
+
+	// Whoever we did not take in above is offered for a manual accept.
+	// This is the ordinary path for a peer with no invite and no auto-accept, and the
+	// fallback for an auto-add that lost a race.
+	if !isBlocked && !known {
 		s.authsLock.Lock()
 		s.ingoingAuths[remotePeer] = authPeer
 		s.authsLock.Unlock()
@@ -268,18 +305,8 @@ func (s *AuthStatus) AuthStreamHandler(stream network.Stream) {
 			PeerID:   peerID,
 		})
 	}
-	if !confirmed && !isBlocked && autoAccept {
-		defer func() {
-			_ = s.AddPeer(context.Background(), AddPeerParams{
-				PeerID:    remotePeer,
-				Name:      authPeer.Name,
-				Alias:     s.conf.GenUniqPeerAlias(authPeer.Name, ""),
-				Confirmed: true,
-			})
-		}()
-	}
 
-	authResponse := protocol.AuthPeerResponse{Confirmed: confirmed, Declined: isBlocked}
+	authResponse := protocol.AuthPeerResponse{Confirmed: known, Declined: isBlocked}
 	err = protocol.SendAuthResponse(stream, authResponse)
 	if err != nil {
 		s.logger.Errorf("sending auth response to %s as an answer: %v", peerID, err)
@@ -287,6 +314,81 @@ func (s *AuthStatus) AuthStreamHandler(stream network.Stream) {
 	}
 
 	s.logger.Infof("Successfully received auth from %s (%s)", authPeer.Name, peerID)
+}
+
+// checkInvite looks up a token from an auth request, without consuming anything.
+func (s *AuthStatus) checkInvite(token, peerID string) (config.Invite, bool) {
+	if token == "" {
+		return config.Invite{}, false
+	}
+
+	invite, err := s.conf.CheckInvite(token)
+	if err != nil {
+		if reason := inviteRejectionReason(err); reason != "" {
+			metrics.InviteTokensRejectedTotal.WithLabelValues(reason).Inc()
+		}
+		s.logger.Infof("peer %s presented an unusable invite token: %v", peerID, err)
+		return config.Invite{}, false
+	}
+
+	return invite, true
+}
+
+func inviteRejectionReason(err error) string {
+	switch {
+	case errors.Is(err, config.ErrInviteExpired):
+		return "expired"
+	case errors.Is(err, config.ErrInviteRevoked):
+		return "revoked"
+	case errors.Is(err, config.ErrInviteUsedUp):
+		return "used_up"
+	case errors.Is(err, config.ErrInviteNotFound):
+		return "unknown"
+	}
+	return ""
+}
+
+// addPeerFromAuth adds a peer that arrived with a valid invite token or under AutoAcceptAuthRequests.
+// A valid token has a priority and applies the invite's settings.
+func (s *AuthStatus) addPeerFromAuth(remotePeer peer.ID, authPeer protocol.AuthPeer, invite config.Invite, inviteValid bool) bool {
+	params := AddPeerParams{
+		PeerID:        remotePeer,
+		Name:          authPeer.Name,
+		Confirmed:     true,
+		UniquifyAlias: true,
+	}
+	if inviteValid {
+		// The invite's own settings are read by AddPeer, from the invite it
+		// redeems — not copied from the check above, which is only advisory.
+		params.RedeemInviteToken = invite.Token
+	}
+
+	err := s.AddPeer(context.Background(), params)
+	if err != nil {
+		// Also covers the invite going unusable between the check above and the
+		// redemption inside AddPeer (two holders of a single-use link arriving together).
+		if reason := inviteRejectionReason(err); reason != "" {
+			metrics.InviteTokensRejectedTotal.WithLabelValues(reason).Inc()
+		}
+		s.logger.Errorf("failed to auto-add peer %s (from invite: %v) %s: %v", params.Name, inviteValid, params.PeerID, err)
+		return false
+	}
+
+	if inviteValid {
+		s.onInviteRedeemed(remotePeer.String(), params.Name, invite.ID)
+	}
+
+	return true
+}
+
+func (s *AuthStatus) onInviteRedeemed(peerID, peerName, inviteID string) {
+	metrics.InvitesRedeemedTotal.Inc()
+	s.logger.Infof("peer %s %s was added automatically through invite %s", peerName, peerID, inviteID)
+	// TODO: surface this in the UI, or at least as a tray notification
+	_ = s.inviteEmitter.Emit(awlevent.InviteRedeemed{
+		PeerID:   peerID,
+		InviteID: inviteID,
+	})
 }
 
 func (s *AuthStatus) SendAuthRequest(ctx context.Context, peerID peer.ID, req protocol.AuthPeer) error {
@@ -346,6 +448,11 @@ type AddPeerParams struct {
 	Name string
 	// Alias is the local name for the peer, chosen by us.
 	Alias string
+	// UniquifyAlias makes a clashing (or empty) Alias be resolved into a free
+	// one instead of failing, under the same lock that inserts the peer. Set it
+	// on paths with no user to report a clash to; a user-driven add leaves it
+	// false so the error reaches the form that caused it.
+	UniquifyAlias bool
 	// Confirmed reports whether the peer has already confirmed us, i.e. we are
 	// accepting its request rather than sending our own.
 	Confirmed bool
@@ -354,6 +461,13 @@ type AddPeerParams struct {
 	// AllowUsingAsExitNode lets the peer use us as a SOCKS5 / VPN Gateway exit node.
 	// Announced to it by the status exchange, see createPeerInfo.
 	AllowUsingAsExitNode bool
+	// RedeemInviteToken is a token of OUR invite, presented to us by the peer.
+	// AddPeer spends one use of the matching invite and takes Alias,
+	// AllowUsingAsExitNode and InviteID from it, overriding whatever was passed here.
+	RedeemInviteToken string
+	// PendingInviteToken is the invite token we present to the peer until it
+	// confirms us. Set on the side that redeems a link.
+	PendingInviteToken string
 }
 
 func (s *AuthStatus) AddPeer(ctx context.Context, params AddPeerParams) error {
@@ -368,7 +482,20 @@ func (s *AuthStatus) AddPeer(ctx context.Context, params AddPeerParams) error {
 		s.conf.Unlock()
 		return fmt.Errorf("peer has already been added")
 	}
-	if !s.conf.IsUniqPeerAliasUnlocked("", alias) {
+	inviteID := ""
+	if params.RedeemInviteToken != "" {
+		invite, err := s.conf.ReserveInviteUnlocked(params.RedeemInviteToken)
+		if err != nil {
+			s.conf.Unlock()
+			return fmt.Errorf("redeeming invite: %w", err)
+		}
+		alias = strings.TrimSpace(invite.Alias)
+		params.AllowUsingAsExitNode = invite.WeAllowUsingAsExitNode
+		inviteID = invite.ID
+	}
+	if params.UniquifyAlias {
+		alias = s.conf.GenUniqPeerAliasUnlocked(params.Name, alias)
+	} else if !s.conf.IsUniqPeerAliasUnlocked("", alias) {
 		s.conf.Unlock()
 		return fmt.Errorf("peer name is not unique")
 	}
@@ -390,6 +517,8 @@ func (s *AuthStatus) AddPeer(ctx context.Context, params AddPeerParams) error {
 		Confirmed:              params.Confirmed,
 		CreatedAt:              time.Now(),
 		WeAllowUsingAsExitNode: params.AllowUsingAsExitNode,
+		InviteID:               inviteID,
+		PendingInviteToken:     params.PendingInviteToken,
 	}
 	newPeerConfig.DomainName = awldns.TrimDomainName(newPeerConfig.DisplayName())
 	s.conf.UpsertPeerUnlocked(newPeerConfig)
@@ -407,7 +536,8 @@ func (s *AuthStatus) AddPeer(ctx context.Context, params AddPeerParams) error {
 		defer cancel()
 		if !params.Confirmed {
 			authPeer := protocol.AuthPeer{
-				Name: s.conf.NodeName(),
+				Name:  s.conf.NodeName(),
+				Token: params.PendingInviteToken,
 			}
 			_ = s.SendAuthRequest(ctx, peerID, authPeer)
 		}
@@ -496,7 +626,8 @@ func (s *AuthStatus) restoreOutgoingAuths() {
 	for _, knownPeer := range s.conf.KnownPeers {
 		if !knownPeer.Confirmed && !knownPeer.Declined {
 			outgoingAuths[knownPeer.PeerId()] = protocol.AuthPeer{
-				Name: peerName,
+				Name:  peerName,
+				Token: knownPeer.PendingInviteToken,
 			}
 		}
 	}

--- a/test_suite_test.go
+++ b/test_suite_test.go
@@ -371,7 +371,7 @@ func (ts *TestSuite) NewSimnetPeerPair(latency time.Duration, bandwidthBps int, 
 // alias1 is how peer2 will know peer1 (set in the reply); alias2 is how peer1
 // will know peer2 (set in the outbound friend request).
 func (ts *TestSuite) sendAndAcceptFriendRequest(peer1, peer2 TestPeer, alias1, alias2 string) {
-	err := peer1.api.SendFriendRequest(peer2.PeerID(), alias2, "")
+	err := peer1.api.SendFriendRequest(entity.FriendRequest{PeerID: peer2.PeerID(), Alias: alias2})
 	ts.NoError(err)
 
 	var authRequests []entity.AuthRequest
@@ -380,7 +380,7 @@ func (ts *TestSuite) sendAndAcceptFriendRequest(peer1, peer2 TestPeer, alias1, a
 		ts.NoError(err)
 		return len(authRequests) == 1
 	}, 15*time.Second, 50*time.Millisecond)
-	err = peer2.api.ReplyFriendRequest(authRequests[0].PeerID, alias1, false, "")
+	err = peer2.api.ReplyFriendRequest(entity.FriendRequestReply{PeerID: authRequests[0].PeerID, Alias: alias1})
 	ts.NoError(err)
 
 	ts.Eventually(func() bool {


### PR DESCRIPTION
Related to #240

An invite link in format `awl://invite?p=<peer_id>&t=<token>&n=<name>`.
Whoever presents the token is added without a manual accept, with
the alias and exit node permission the creator chose when making the link.
Links are single-use and expire in a day by default, and can be revoked; the
token is optional, and without it the link is just the shareable form of a
peer id (that is what `awl cli me id` now prints and puts in its QR).

The invite itself lives in the creator's config, so nothing but the token and a
display name travels in the link, revoking really closes it, and the receiver
can add the creator while it is still offline. A use is spent inside the same
critical section that writes the peer it pays for, so a spent use and an added
peer can never come apart — hence ReserveInviteUnlocked, called from AddPeer
and from the UpdatePeerFields mutator rather than reserved and rolled back.

A token that no longer works degrades into an ordinary auth request for a manual accept.
Blocking still outranks an invite.

Adds config.Invite + Config.Invites, KnownPeer.InviteID (creator's marker) and
KnownPeer.PendingInviteToken (receiver's secret, presented until confirmed and
restored after a restart), the Go link parser in entity/invite_link.go, the
peers/invites/{create,list,revoke} endpoints, awlevent.InviteRedeemed and two
metrics. CLI and GUI come separately.