### PR TITLE
fix: tray icon path was not returned properly

### DIFF
--- a/embeds/icon.go
+++ b/embeds/icon.go
@@ -65,7 +65,7 @@ func EmbedIcon() (string, error) {
 	equal := checkIsFileEqual(iconPath, appIcon)
 	if equal {
 		appIconPath = iconPath
-		return iconDir, nil
+		return iconPath, nil
 	}
 
 	err = os.WriteFile(iconPath, appIcon, iconMode)
@@ -76,7 +76,7 @@ func EmbedIcon() (string, error) {
 
 	appIconPath = iconPath
 
-	return iconDir, nil
+	return iconPath, nil
 }
 
 func RemoveIconIfNeeded() error {


### PR DESCRIPTION
this was resulting in a blank icon in the desktop environment